### PR TITLE
Correcting hex code in CSS example

### DIFF
--- a/app/views/includes/css/confirm.css
+++ b/app/views/includes/css/confirm.css
@@ -1,6 +1,6 @@
 .govuk-box-highlight {
   padding: 1em 2em 2em;
-  background-color: #00823B;
+  background-color: #006435;
   color: #FFF;
   text-align: center;
 


### PR DESCRIPTION
Changed the hex code for the confirmation panel background colour from #00823B to #006435 to match the visual example.