### PR TITLE
Accessibility changes

### DIFF
--- a/app/views/includes/components/pagination.html
+++ b/app/views/includes/components/pagination.html
@@ -1,5 +1,5 @@
 <nav role="navigation" aria-label="Pagination">
-  <div class="pagination__summary">Showing 101 &ndash; 150 of 246 results</div>
+  <div class="pagination__summary">Showing 101 - 150 of 246 results</div>
   <ul class="pagination">
     <li class="pagination__item"><a class="pagination__link" href="#0" aria-label="Previous page"><span aria-hidden="true" role="presentation">&laquo;</span> Previous</a></li>
     <li class="pagination__item"><a class="pagination__link" href="#0" aria-label="Page 1">1</a></li>

--- a/app/views/includes/home-office-logo.html
+++ b/app/views/includes/home-office-logo.html
@@ -1,7 +1,7 @@
 
       <?xml version="1.0" encoding="UTF-8" standalone="no"?>
       <svg preserveAspectRatio="xMinYMin meet" viewBox="0 0 578 138" version="1.1" class="svg-logo">
-        <title>Home_Office</title>
+        <title>Home Office</title>
         <defs></defs>
         <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
           <g id="Home_Office" fill-rule="nonzero">


### PR DESCRIPTION
Removed emdash in pagination html and removed underscore in home office logo htmk due to accessibility errors.

Also removed the secondary link override in the gov frontend node as this was causing colour contrast errors. Not sure if this has committed