### PR TITLE
Fix errant apostrophe

### DIFF
--- a/app/views/includes/components/conf--casework.html
+++ b/app/views/includes/components/conf--casework.html
@@ -3,7 +3,7 @@
   <h2 class="govuk-heading-l">
     Request received
   </h2>
-  <p>We have sent you a confirmation email and you can <a href="#0">view your request and it&rsquo;s current status</a>.</p>
+  <p>We have sent you a confirmation email and you can <a href="#0">view your request and its current status</a>.</p>
 </div>
 
 <h2 class="govuk-heading-m">What happens next</h2>


### PR DESCRIPTION
This commit removes an apostrophe that shouldn't be there.

> Hi folks: there's a typo in the "Request received" example. "...and its current status" should *not* have an apostrophe in "it's".
> 
> ![image](https://user-images.githubusercontent.com/26182217/71012982-db7a9700-20e7-11ea-87da-557e684aca37.png)
> 
> _Originally posted by @martinwake in https://github.com/UKHomeOffice/design-system/issues/90#issuecomment-566623818_
> 