### PR TITLE
references to icons removed

### DIFF
--- a/app/views/components/back.html
+++ b/app/views/components/back.html
@@ -20,7 +20,6 @@ Back link - Home Office design system
       <p class="govuk-body-l">A control to navigate back to the previous page of a service.</p>
 
       <h2 class="govuk-heading-m" id="example-component">Example components</h2>
-      <p class="icon-hint">This pattern uses icons. Please refer to our <a href="/styles/icons">icons page</a> on how to use them.</p>
       <div class="example example-images">
         <div class="govuk-grid-row">
           {% include "includes/components/back.html" %}

--- a/app/views/components/back.html
+++ b/app/views/components/back.html
@@ -49,11 +49,6 @@ Back link - Home Office design system
       <p>We have seen some users not understand the context of the current back link design. This has caused them anxiety.</p>
       <p>Some users have been concerned that using the back link would lose their work.</p>
 
-      <h2 class="govuk-heading-m">Related components</h2>
-      <ul class="govuk-list govuk-list--bullet">
-        <li><a href="/styles/icons">Icons</a></li>
-      </ul>
-
       <div class="contact-us">
         <h2 class="govuk-heading-m">Get in touch</h2>
         <p>If you’ve got a question or suggestion share it on Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system channel</a> or on <a href="https://github.com/UKHomeOffice/home-office-digital-patterns/issues/95">GitHub</a>.</p>

--- a/app/views/components/confirm-pages.html
+++ b/app/views/components/confirm-pages.html
@@ -20,7 +20,6 @@ Confirmation pages - Home Office design system
       <p class="govuk-body-l">Different confirmation pages based on different scenarios.</p>
 
       <h2 class="govuk-heading-m" id="example-component">External confirmation</h2>
-      <p class="icon-hint">This pattern uses icons. Please refer to our <a href="/styles/icons">icons page</a> on how to use them.</p>
       <p>If it&rsquo;s for an external application aim to send the user a confirmation email but provide a reference number as well.</p>
 
       <div class="example example-images">
@@ -40,7 +39,6 @@ Confirmation pages - Home Office design system
       </details>
 
       <h2 class="govuk-heading-m" id="example-component">Self service confirmation</h2>
-      <p class="icon-hint">This pattern uses icons. Please refer to our <a href="/styles/icons">icons page</a> on how to use them.</p>
       <p>If it&rsquo;s an internal process confirm complete and allow a link back to previous section.</p>
 
       <div class="example example-images">
@@ -60,7 +58,6 @@ Confirmation pages - Home Office design system
       </details>
 
       <h2 class="govuk-heading-m" id="example-component">Application confirmation</h2>
-      <p class="icon-hint">This pattern uses icons. Please refer to our <a href="/styles/icons">icons page</a> on how to use them.</p>
       <p>If more actions will take place, e.g. caseworking, provide details below.</p>
 
       <div class="example example-images">


### PR DESCRIPTION
Have removed links and references to the icons page (removed in previous branch) in the following Component pages:
- back link
- confirmation pages