### PR TITLE
Contact card: Updated email and github link

### DIFF
--- a/app/views/community/backlog.html
+++ b/app/views/community/backlog.html
@@ -21,7 +21,7 @@ Backlog - Home Office design system
 
       <p>To contribute, you can create and comment on an <a href="https://github.com/UKHomeOffice/home-office-digital-patterns/issues">issue in GitHub</a>.You don’t need to upload anything to Git to contribute.</p>
 
-      <p>The best place to discuss patterns and components is on Slack. But you can also <a href="mailto:designops@digital.homeoffice.gov.uk">email the working group</a> or talk to us in person.</p>
+      <p>The best place to discuss patterns and components is on Slack. But you can also <a href="mailto:design@digital.homeoffice.gov.uk">email the working group</a> or talk to us in person.</p>
     </div>
 
   </main>

--- a/app/views/community/propose.html
+++ b/app/views/community/propose.html
@@ -25,7 +25,7 @@ Propose - Home Office design system
       <p>Talk about the pattern or component to the community. Share your work, as other teams might be working on the same thing. Gather feedback and examples from the community.</p>
 
       <h2 class="govuk-heading-m">3. Raise a new issue</h2>
-      <p>If your idea is not on the backlog, <a href="https://github.com/UKHomeOffice/design-system/issues">raise an issue in Github</a>. Or get in touch with <a href="mailto:designops@digital.homeoffice.gov.uk">the working group</a> to help you do this.</p>
+      <p>If your idea is not on the backlog, <a href="https://github.com/UKHomeOffice/design-system/issues">raise an issue in Github</a>. Or get in touch with <a href="mailto:design@digital.homeoffice.gov.uk">the working group</a> to help you do this.</p>
       <p> The working group will get in touch to discuss your proposal.</P>
       <p>When raising an issue, explain why you think it should be included in the design system. You can also include screenshots and research notes.</p>
 

--- a/app/views/community/working.html
+++ b/app/views/community/working.html
@@ -23,7 +23,7 @@ Working group - Home Office design system
 
       <p>It is a cross-functional team made up of interaction and content design, user research, accessibility, and front-end development.</p>
 
-      <p>You can contact the working group on the Home Office #ho-design-system slack channel, or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
+      <p>You can contact the working group on the Home Office #ho-design-system slack channel, or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
 
     </div>
 

--- a/app/views/components/alerts.html
+++ b/app/views/components/alerts.html
@@ -51,7 +51,7 @@ Alerts - Home Office design system
 
       <div class="contact-us">
        <h2 class="govuk-heading-m">Get in touch</h2>
-       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
+       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
      </div>
 
     </div>

--- a/app/views/components/back.html
+++ b/app/views/components/back.html
@@ -51,7 +51,7 @@ Back link - Home Office design system
 
       <div class="contact-us">
        <h2 class="govuk-heading-m">Get in touch</h2>
-       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
+       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
      </div>
 
     </div>

--- a/app/views/components/buttons.html
+++ b/app/views/components/buttons.html
@@ -90,7 +90,7 @@ Buttons - Home Office design system
 
       <div class="contact-us">
        <h2 class="govuk-heading-m">Get in touch</h2>
-       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
+       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
      </div>
 
     </div>

--- a/app/views/components/cards.html
+++ b/app/views/components/cards.html
@@ -38,7 +38,7 @@ Cards - Home Office design system
 
       <div class="contact-us">
        <h2 class="govuk-heading-m">Get in touch</h2>
-       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
+       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
      </div>
 
     </div>

--- a/app/views/components/checkboxes.html
+++ b/app/views/components/checkboxes.html
@@ -75,7 +75,7 @@ Checkboxes - Home Office design system
 
       <div class="contact-us">
        <h2 class="govuk-heading-m">Get in touch</h2>
-       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
+       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
      </div>
 
     </div>

--- a/app/views/components/confirm-pages.html
+++ b/app/views/components/confirm-pages.html
@@ -107,7 +107,7 @@ Confirmation pages - Home Office design system
 
       <div class="contact-us">
        <h2 class="govuk-heading-m">Get in touch</h2>
-       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
+       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
      </div>
 
     </div>

--- a/app/views/components/highlighting-matches.html
+++ b/app/views/components/highlighting-matches.html
@@ -48,7 +48,7 @@ Highlighted search matches - Home Office design system
 
       <div class="contact-us">
        <h2 class="govuk-heading-m">Get in touch</h2>
-       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
+       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
      </div>
 
     </div>

--- a/app/views/components/labels-bu.html
+++ b/app/views/components/labels-bu.html
@@ -54,7 +54,7 @@ Labels - Home Office design system
 
       <div class="contact-us">
        <h2 class="govuk-heading-m">Get in touch</h2>
-       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
+       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
      </div>
 
     </div>

--- a/app/views/components/labels.html
+++ b/app/views/components/labels.html
@@ -51,10 +51,10 @@ Labels - Home Office design system
         <img src="{{ asset_path }}/images/placeholder.png" alt="Staged photo of a large group of people in a line." class="image-examples">
 <p>Syrian refugee resettlement service</p>
 
-  <div class="contact-us">
-    <h2 class="govuk-heading-m">Get in touch</h2>
-    <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
-  </div>
+<div class="contact-us">
+ <h2 class="govuk-heading-m">Get in touch</h2>
+ <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
+</div>
 
     </div>
   </main>

--- a/app/views/components/navigation.html
+++ b/app/views/components/navigation.html
@@ -61,7 +61,7 @@ Sub-navigation - Home Office design system
 
       <div class="contact-us">
        <h2 class="govuk-heading-m">Get in touch</h2>
-       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
+       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
      </div>
 
     </div>

--- a/app/views/components/pagination.html
+++ b/app/views/components/pagination.html
@@ -65,7 +65,7 @@ Pagination - Home Office design system
 
         <div class="contact-us">
          <h2 class="govuk-heading-m">Get in touch</h2>
-         <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
+         <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
        </div>
 
     </div>

--- a/app/views/components/radios.html
+++ b/app/views/components/radios.html
@@ -73,7 +73,7 @@ Radios - Home Office design system
 
       <div class="contact-us">
        <h2 class="govuk-heading-m">Get in touch</h2>
-       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
+       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
      </div>
 
     </div>

--- a/app/views/components/side-tab.html
+++ b/app/views/components/side-tab.html
@@ -61,7 +61,7 @@ Side tab - Home Office design system
 
       <div class="contact-us">
        <h2 class="govuk-heading-m">Get in touch</h2>
-       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
+       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
      </div>
 
     </div>

--- a/app/views/components/status.html
+++ b/app/views/components/status.html
@@ -54,7 +54,7 @@ Status message - Home Office design system
 
       <div class="contact-us">
        <h2 class="govuk-heading-m">Get in touch</h2>
-       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
+       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
      </div>
 
     </div>

--- a/app/views/components/table-multiselect.html
+++ b/app/views/components/table-multiselect.html
@@ -39,7 +39,7 @@ Table multi-select - Home Office design system
 
       <div class="contact-us">
        <h2 class="govuk-heading-m">Get in touch</h2>
-       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
+       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
      </div>
 
     </div>

--- a/app/views/components/timeline.html
+++ b/app/views/components/timeline.html
@@ -50,7 +50,7 @@ Timeline - Home Office design system
 
       <div class="contact-us">
        <h2 class="govuk-heading-m">Get in touch</h2>
-       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
+       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
      </div>
 
     </div>

--- a/app/views/patterns/case-summary.html
+++ b/app/views/patterns/case-summary.html
@@ -48,7 +48,7 @@ Case summary - Home Office design system
 
         <div class="contact-us">
          <h2 class="govuk-heading-m">Get in touch</h2>
-         <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
+         <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
        </div>
 
     </div>

--- a/app/views/patterns/confirmation-loop.html
+++ b/app/views/patterns/confirmation-loop.html
@@ -57,7 +57,7 @@ Check and confirm - Home Office design system
 
       <div class="contact-us">
        <h2 class="govuk-heading-m">Get in touch</h2>
-       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
+       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
      </div>
 
     </div>

--- a/app/views/patterns/enquiry.html
+++ b/app/views/patterns/enquiry.html
@@ -65,7 +65,7 @@ Enquiry - Home Office design system
 
       <div class="contact-us">
        <h2 class="govuk-heading-m">Get in touch</h2>
-       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
+       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
      </div>
 
   </main>

--- a/app/views/patterns/error-pages.html
+++ b/app/views/patterns/error-pages.html
@@ -57,7 +57,7 @@ Error pages - Home Office design system
 
       <div class="contact-us">
        <h2 class="govuk-heading-m">Get in touch</h2>
-       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
+       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
      </div>
 
     </div>

--- a/app/views/patterns/guidance-image.html
+++ b/app/views/patterns/guidance-image.html
@@ -136,15 +136,9 @@ Guidance images - Home Office design system
       </ul>
 
       <div class="contact-us">
-<<<<<<< HEAD
        <h2 class="govuk-heading-m">Get in touch</h2>
-       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
+       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
      </div>
-=======
-        <h2 class="govuk-heading-m">Get in touch</h2>
-        <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
-      </div>
->>>>>>> 62354ece4adbebd04a8a9f113e18511178db1aab
 
     </div>
 

--- a/app/views/patterns/help.html
+++ b/app/views/patterns/help.html
@@ -51,7 +51,7 @@ Contextual help - Home Office design system
 
       <div class="contact-us">
        <h2 class="govuk-heading-m">Get in touch</h2>
-       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
+       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
      </div>
 
     </div>

--- a/app/views/patterns/identifying-users.html
+++ b/app/views/patterns/identifying-users.html
@@ -92,7 +92,7 @@ Authentication - Home Office design system
 
       <div class="contact-us">
        <h2 class="govuk-heading-m">Get in touch</h2>
-       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
+       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
      </div>
 
     </div>

--- a/app/views/patterns/interruption-card.html
+++ b/app/views/patterns/interruption-card.html
@@ -70,7 +70,7 @@ Interruption card - Home Office design system
 
       <div class="contact-us">
        <h2 class="govuk-heading-m">Get in touch</h2>
-       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
+       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
      </div>
 
     </div>

--- a/app/views/patterns/modal.html
+++ b/app/views/patterns/modal.html
@@ -22,7 +22,7 @@ Modal window - Home Office design system
       <h2 class="govuk-heading-m">When to use this pattern</h2>
       <p>Modals should be avoided in most cases. They are hard to make accessible and do not work well in mobile views.</p>
       <p>Adding content to a new page instead of showing it in a modal should be the default approach.</p>
-      <p>Modals can be useful when you need to draw a users attention to something, for example timeout warnings. Please discuss with the wider community or email <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a> before using this pattern.</p>
+      <p>Modals can be useful when you need to draw a users attention to something, for example timeout warnings. Please discuss with the wider community or email <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a> before using this pattern.</p>
 
       <h2 id="interaction" class="govuk-heading-m">How modals work</h2>
       <p>A modal should focus on a single task.</p>
@@ -43,7 +43,7 @@ Modal window - Home Office design system
 
       <div class="contact-us">
        <h2 class="govuk-heading-m">Get in touch</h2>
-       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
+       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
      </div>
 
     </div>

--- a/app/views/patterns/multiple-loops.html
+++ b/app/views/patterns/multiple-loops.html
@@ -57,7 +57,7 @@ Multiple loops - Home Office design system
 
       <div class="contact-us">
        <h2 class="govuk-heading-m">Get in touch</h2>
-       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
+       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
      </div>
 
     </div>

--- a/app/views/patterns/postcode.html
+++ b/app/views/patterns/postcode.html
@@ -50,7 +50,7 @@ Postcode lookup - Home Office design system
 
       <div class="contact-us">
        <h2 class="govuk-heading-m">Get in touch</h2>
-       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
+       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
      </div>
 
     </div>

--- a/app/views/patterns/sign-out.html
+++ b/app/views/patterns/sign-out.html
@@ -60,7 +60,7 @@ Leaving a service - Home Office design system
 
       <div class="contact-us">
        <h2 class="govuk-heading-m">Get in touch</h2>
-       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
+       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
      </div>
 
     </div>

--- a/app/views/patterns/support.html
+++ b/app/views/patterns/support.html
@@ -40,7 +40,7 @@ Support - Home Office design system
 
       <div class="contact-us">
        <h2 class="govuk-heading-m">Get in touch</h2>
-       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
+       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
      </div>
 
     </div>

--- a/app/views/patterns/upload-file.html
+++ b/app/views/patterns/upload-file.html
@@ -54,7 +54,7 @@ Add a file - Home Office design system
 
       <div class="contact-us">
        <h2 class="govuk-heading-m">Get in touch</h2>
-       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
+       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
      </div>
 
     </div>

--- a/app/views/styles/images.html
+++ b/app/views/styles/images.html
@@ -31,7 +31,7 @@ Images - Home Office design system
       <p class="govuk-body">Images must be relevant to the content, help users understand what they need to do and follow our guidance on the use of <a href="#Alternative text">Alternative text</a>.</p>
 
       <h3 class="govuk-heading-m">Sourcing images</h3>
-      <p>Please contact the design system working group (<a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>) for advice on image use, for original source files and to commission illustrations.</p>
+      <p>Please contact the design system working group (<a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>) for advice on image use, for original source files and to commission illustrations.</p>
 
       <h2 id="Illustrations or representative imagery" class="govuk-heading-l">Illustrations or representative imagery</h2>
       <p class="govuk-body">If your image represents something physical, such as a document, you should use the aspect ratio of that object.</p>
@@ -109,9 +109,9 @@ Images - Home Office design system
       <p class="govuk-body">Alternative text, or alt text, is read out by screen readers for those with visual impairments. It will also be displayed if an image does not load or if images have been switched off. We recommend following the guidance in the <a href="https://design-system.service.gov.uk/styles/images/" target=blank>GOV.UK Design System</a> on the use of alt text.</p>
 
       <div class="contact-us">
-        <h2 class="govuk-heading-m">Get in touch</h2>
-        <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system channel</a>, on <a href="https://github.com/UKHomeOffice/design-system" target=blank>GitHub</a> or email the design system working group on <a href="mailto:designops@digital.homeoffice.gov.uk">designops@digital.homeoffice.gov.uk</a>.</p>
-      </div>
+       <h2 class="govuk-heading-m">Get in touch</h2>
+       <p>If you’ve got a question or suggestion share it on the Slack <a href="slack://channel?id=CTXV6L1K4&team=T03TJ3P61">#ho-design-system</a> channel, on <a href="https://github.com/UKHomeOffice/design-system">GitHub</a> or email the design system working group on <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>.</p>
+     </div>
 
     </div>
 


### PR DESCRIPTION
I've updated the contact card following an initial accessibility review:
- github link now opens in same tab
- have updated/replaced all instances of the dessignops email with design@ on these pages:
All components, all patterns, Styles:images, Community (Get Involved) - working group, suggest and backlog.