### PR TITLE
Sidenav fix

### DIFF
--- a/app/assets/sass/system/_subnav.scss
+++ b/app/assets/sass/system/_subnav.scss
@@ -64,7 +64,7 @@
   .app-subnav__theme {
     margin: 0;
     padding: govuk-spacing(2) govuk-spacing(3);
-    color: govuk-colour("grey-1");
+    color: #4a5256;
     @include govuk-font(19);
   }
 }

--- a/app/views/includes/left-pane__components.html
+++ b/app/views/includes/left-pane__components.html
@@ -1,7 +1,7 @@
 <div class="app-pane__subnav app-hide-mobile">
-  <nav class="app-subnav">
+  <nav class="app-subnav" aria-labelledby="sidemenulabel">
     <h2 id="sidemenulabel" class="visuallyhidden">Side Menu</h2>
-    
+
     <ul class="app-subnav__section">
       <li{% if activesub == "alerts" %} class="app-subnav__section-item app-subnav__section-item--current"{% endif %}>
         <a class="app-subnav__link govuk-link" href="/components/alerts">Alerts</a>

--- a/app/views/includes/left-pane__components.html
+++ b/app/views/includes/left-pane__components.html
@@ -1,5 +1,7 @@
 <div class="app-pane__subnav app-hide-mobile">
   <nav class="app-subnav">
+    <h2 id="sidemenulabel" class="visuallyhidden">Side Menu</h2>
+    
     <ul class="app-subnav__section">
       <li{% if activesub == "alerts" %} class="app-subnav__section-item app-subnav__section-item--current"{% endif %}>
         <a class="app-subnav__link govuk-link" href="/components/alerts">Alerts</a>

--- a/app/views/includes/left-pane__contribute.html
+++ b/app/views/includes/left-pane__contribute.html
@@ -1,5 +1,6 @@
 <div class="app-pane__subnav app-hide-mobile">
   <nav class="app-subnav">
+    <h2 id="sidemenulabel" class="visuallyhidden">Side Menu</h2>
 
     <ul class="app-subnav__section">
       <li{% if activesub == "working" %} class="app-subnav__section-item app-subnav__section-item--current"{% endif %}>

--- a/app/views/includes/left-pane__contribute.html
+++ b/app/views/includes/left-pane__contribute.html
@@ -1,5 +1,5 @@
 <div class="app-pane__subnav app-hide-mobile">
-  <nav class="app-subnav">
+  <nav class="app-subnav" aria-labelledby="sidemenulabel">
     <h2 id="sidemenulabel" class="visuallyhidden">Side Menu</h2>
 
     <ul class="app-subnav__section">

--- a/app/views/includes/left-pane__patterns.html
+++ b/app/views/includes/left-pane__patterns.html
@@ -1,5 +1,5 @@
 <div class="app-pane__subnav app-hide-mobile">
-  <nav class="app-subnav">
+  <nav class="app-subnav" aria-labelledby="sidemenulabel">
     <h2 id="sidemenulabel" class="visuallyhidden">Side Menu</h2>
 
     <h4 class="app-subnav__theme">Ask users for…</h4>

--- a/app/views/includes/left-pane__patterns.html
+++ b/app/views/includes/left-pane__patterns.html
@@ -1,5 +1,6 @@
 <div class="app-pane__subnav app-hide-mobile">
   <nav class="app-subnav">
+    <h2 id="sidemenulabel" class="visuallyhidden">Side Menu</h2>
 
     <h4 class="app-subnav__theme">Ask users for…</h4>
     <ul class="app-subnav__section">

--- a/app/views/includes/left-pane__resources.html
+++ b/app/views/includes/left-pane__resources.html
@@ -1,5 +1,7 @@
 <div class="app-pane__subnav app-hide-mobile">
   <nav class="app-subnav">
+    <h2 id="sidemenulabel" class="visuallyhidden">Side Menu</h2>
+    
     <ul class="app-subnav__section">
       <li{% if activesub == "accessibility" %} class="app-subnav__section-item app-subnav__section-item--current"{% endif %}>
         <a class="app-subnav__link govuk-link" href="/resources/accessibility">Accessibility</a>

--- a/app/views/includes/left-pane__resources.html
+++ b/app/views/includes/left-pane__resources.html
@@ -1,7 +1,7 @@
 <div class="app-pane__subnav app-hide-mobile">
-  <nav class="app-subnav">
+  <nav class="app-subnav" aria-labelledby="sidemenulabel">
     <h2 id="sidemenulabel" class="visuallyhidden">Side Menu</h2>
-    
+
     <ul class="app-subnav__section">
       <li{% if activesub == "accessibility" %} class="app-subnav__section-item app-subnav__section-item--current"{% endif %}>
         <a class="app-subnav__link govuk-link" href="/resources/accessibility">Accessibility</a>

--- a/app/views/includes/left-pane__styles-bu.html
+++ b/app/views/includes/left-pane__styles-bu.html
@@ -1,5 +1,7 @@
 <div class="app-pane__subnav app-hide-mobile">
   <nav class="app-subnav">
+    <h2 id="sidemenulabel" class="visuallyhidden">Side Menu</h2>
+    
     <ul class="app-subnav__section">
       <li{% if activesub == "colour" %} class="app-subnav__section-item app-subnav__section-item--current"{% endif %}>
         <a class="app-subnav__link govuk-link" href="/styles/colour">Colour</a>

--- a/app/views/includes/left-pane__styles-bu.html
+++ b/app/views/includes/left-pane__styles-bu.html
@@ -1,7 +1,7 @@
 <div class="app-pane__subnav app-hide-mobile">
-  <nav class="app-subnav">
+  <nav class="app-subnav" aria-labelledby="sidemenulabel">
     <h2 id="sidemenulabel" class="visuallyhidden">Side Menu</h2>
-    
+
     <ul class="app-subnav__section">
       <li{% if activesub == "colour" %} class="app-subnav__section-item app-subnav__section-item--current"{% endif %}>
         <a class="app-subnav__link govuk-link" href="/styles/colour">Colour</a>

--- a/app/views/includes/left-pane__styles.html
+++ b/app/views/includes/left-pane__styles.html
@@ -1,5 +1,7 @@
 <div class="app-pane__subnav app-hide-mobile">
   <nav class="app-subnav">
+    <h2 id="sidemenulabel" class="visuallyhidden">Side Menu</h2>
+    
     <ul class="app-subnav__section">
       <li{% if activesub == "colour" %} class="app-subnav__section-item app-subnav__section-item--current"{% endif %}>
         <a class="app-subnav__link govuk-link" href="/styles/colour">Colour</a>

--- a/app/views/includes/left-pane__styles.html
+++ b/app/views/includes/left-pane__styles.html
@@ -1,7 +1,7 @@
 <div class="app-pane__subnav app-hide-mobile">
-  <nav class="app-subnav">
+  <nav class="app-subnav" aria-labelledby="sidemenulabel">
     <h2 id="sidemenulabel" class="visuallyhidden">Side Menu</h2>
-    
+
     <ul class="app-subnav__section">
       <li{% if activesub == "colour" %} class="app-subnav__section-item app-subnav__section-item--current"{% endif %}>
         <a class="app-subnav__link govuk-link" href="/styles/colour">Colour</a>

--- a/app/views/includes/top_nav.html
+++ b/app/views/includes/top_nav.html
@@ -1,4 +1,4 @@
-  <nav class="app-navigation govuk-clearfix">
+  <nav class="app-navigation govuk-clearfix" aria-labelledby="mainmenulabel">
     <h2 id="mainmenulabel" class="visuallyhidden">Main Menu</h2>
 
     <ul class="app-navigation__list">
@@ -19,4 +19,8 @@
       </li>
     </ul>
 
+  </nav>
+
+  <nav aria-labelledby="mainmenulabel">
+    <h2 id="mainmenulabel" class="visuallyhidden">Main Menu</h2>
   </nav>

--- a/app/views/includes/top_nav.html
+++ b/app/views/includes/top_nav.html
@@ -1,21 +1,22 @@
   <nav class="app-navigation govuk-clearfix">
+    <h2 id="mainmenulabel" class="visuallyhidden">Main Menu</h2>
 
-      <ul class="app-navigation__list">
-        <li{% if active == "styles" %} class="current-page"{% endif %}>
-          <a class="govuk-link" href="/styles">Styles</a>
-        </li>
-        <li{% if active == "components" %} class="current-page"{% endif %}>
-          <a class="govuk-link" href="/components">Components</a>
-        </li>
-        <li{% if active == "patterns" %} class="current-page"{% endif %}>
-          <a class="govuk-link" href="/patterns">Patterns</a>
-        </li>
-        <li{% if active == "resources" %} class="current-page"{% endif %}>
-          <a class="govuk-link" href="/resources">Resources</a>
-        </li>
-        <li{% if active == "community" %} class="current-page"{% endif %}>
-          <a class="govuk-link" href="/community">Get involved</a>
-        </li>
-      </ul>
+    <ul class="app-navigation__list">
+      <li{% if active == "styles" %} class="current-page"{% endif %}>
+        <a class="govuk-link" href="/styles">Styles</a>
+      </li>
+      <li{% if active == "components" %} class="current-page"{% endif %}>
+        <a class="govuk-link" href="/components">Components</a>
+      </li>
+      <li{% if active == "patterns" %} class="current-page"{% endif %}>
+        <a class="govuk-link" href="/patterns">Patterns</a>
+      </li>
+      <li{% if active == "resources" %} class="current-page"{% endif %}>
+        <a class="govuk-link" href="/resources">Resources</a>
+      </li>
+      <li{% if active == "community" %} class="current-page"{% endif %}>
+        <a class="govuk-link" href="/community">Get involved</a>
+      </li>
+    </ul>
 
   </nav>

--- a/app/views/includes/top_nav.html
+++ b/app/views/includes/top_nav.html
@@ -20,7 +20,3 @@
     </ul>
 
   </nav>
-
-  <nav aria-labelledby="mainmenulabel">
-    <h2 id="mainmenulabel" class="visuallyhidden">Main Menu</h2>
-  </nav>


### PR DESCRIPTION
Hi

- Amended the colour contrast with the theme headings in the subnav
- Added aria-labels for all the sidenav components (style, component, pattern etc.) and global header for screen readers 

- I've decided not to change the focus state from your recommendation @kitation, for now that is, as I think just upping the boldness of the yellow might be a band aid fix, where the underlying problem might lie in the focus state itself (it being a border-color change rather than background-color change like gov.uk). This is something I will raise with the team and come up with some actions.