### PR TITLE
Accessibility issues corrected

### DIFF
--- a/app/assets/sass/components/_buttons.scss
+++ b/app/assets/sass/components/_buttons.scss
@@ -30,12 +30,12 @@
 
 .button-secondary {
 	background-color: $panel-colour;
-  box-shadow: 0 1px 0 $text-colour;
+  	box-shadow: 0 1px 0 $text-colour;
 	color: $text-colour;
-  border: $text-colour 1px solid;
-  &[disabled]:active {
+  	border: $text-colour 1px solid;
+  	&[disabled]:active {
 		background-color: $border-colour;
-    box-shadow: 0 0px 0 $black;
+    	box-shadow: 0 0px 0 $black;
   }
 }
 

--- a/app/views/includes/components/button-primary-alt.html
+++ b/app/views/includes/components/button-primary-alt.html
@@ -1,11 +1,11 @@
 <div class="flash-card">
 	<div class="block-space">
-		<button class="govuk-button button-white" data-module="">
+		<button class="govuk-button button-white">
 			Primary action
 		</button>
 	</div>
 	<div class="block-space">
-		<button class="govuk-button button-white" data-module="">
+		<button class="govuk-button button-white govuk-button-disabled" disabled>
 			Disabled primary action
 		</button>
 	</div>

--- a/app/views/includes/components/button-primary-alt.html
+++ b/app/views/includes/components/button-primary-alt.html
@@ -1,8 +1,13 @@
 <div class="flash-card">
 	<div class="block-space">
-		<input class="govuk-button button-white" type="submit" value="Primary action">
+		<button class="govuk-button button-white" data-module="">
+			Primary action
+		</button>
 	</div>
 	<div class="block-space">
-		<input class="govuk-button button-white" type="submit" value="Disabled primary action" disabled>
+		<button class="govuk-button button-white" data-module="">
+			Disabled primary action
+		</button>
 	</div>
 </div>
+

--- a/app/views/includes/components/buttons-secondary.html
+++ b/app/views/includes/components/buttons-secondary.html
@@ -1,11 +1,11 @@
 <div class="block-space">
-	<button class="govuk-button button-secondary" data-module="">
+	<button class="govuk-button button-secondary">
 		Secondary action
 	</button>
 </div>
 
 <div class="block-space">
-	<button class="govuk-button button-affordance" data-module="">
+	<button class="govuk-button button-affordance">
 		<span class="hod-download-button side-space icon-small"></span>
 		Download an item
 	</button>

--- a/app/views/includes/components/buttons-secondary.html
+++ b/app/views/includes/components/buttons-secondary.html
@@ -1,12 +1,12 @@
 <div class="block-space">
-	<a class="govuk-button button-secondary" type="submit" tabindex="0">
-		On page action
-	</a>
+	<button class="govuk-button button-secondary" data-module="">
+		Secondary action
+	</button>
 </div>
 
 <div class="block-space">
-	<a class="govuk-button button-affordance" type="submit" tabindex="0">
+	<button class="govuk-button button-affordance" data-module="">
 		<span class="hod-download-button side-space icon-small"></span>
 		Download an item
-	</a>
+	</button>
 </div>

--- a/app/views/includes/components/buttons.html
+++ b/app/views/includes/components/buttons.html
@@ -1,11 +1,11 @@
 <div class="block-space">
-	<button class="govuk-button" data-module="">
+	<button class="govuk-button" >
 		Primary action
 	</button>
 </div>
 
 <div class="block-space">
-	<button class="govuk-button govuk-button-disabled" data-module="" disabled>
+	<button class="govuk-button govuk-button-disabled" disabled>
 		Disabled primary action
 	</button>
 </div>

--- a/app/views/includes/components/buttons.html
+++ b/app/views/includes/components/buttons.html
@@ -1,6 +1,13 @@
 <div class="block-space">
-	<input class="govuk-button" type="submit" value="Primary action">
+	<button class="govuk-button" data-module="">
+		Primary action
+	</button>
 </div>
+
 <div class="block-space">
-	<input class="govuk-button" type="submit" value="Disabled primary action" disabled>
+	<button class="govuk-button govuk-button-disabled" data-module="" disabled>
+		Disabled primary action
+	</button>
 </div>
+
+

--- a/app/views/includes/components/highlighting.html
+++ b/app/views/includes/components/highlighting.html
@@ -18,6 +18,8 @@
   </thead>
   <tbody>
     <tr class="govuk-table__row">
+      <!-- EXAMPLE -->
+      <!-- <td class="govuk-table__cell"><mark aria-label="highlighted search term">Niles Turnball</mark></td> -->
       <td class="govuk-table__cell"><span class="highlight">Niles Turnball</span></td>
       <td class="govuk-table__cell"><span class="highlight">SW19 Q2C</span> </td>
       <td class="govuk-table__cell" class="numeric">4 March 2017</td>

--- a/app/views/includes/components/table-multiselect.html
+++ b/app/views/includes/components/table-multiselect.html
@@ -6,6 +6,7 @@
         <div class="govuk-checkboxes__item">
           <input type="checkbox" class="govuk-checkboxes__input jsCheckboxAll" id="radio-all">
           <label class="govuk-label govuk-checkboxes__label" for="radio-all">
+            <span class="visually-hidden">Select all</span>
             &nbsp;
           </label>
         </div>
@@ -20,7 +21,9 @@
           <div class="govuk-checkboxes__item">
             <input type="checkbox" class="govuk-checkboxes__input jsCheckbox" id="radio-{{ loop.index }}">
             <label class="govuk-label govuk-checkboxes__label" for="radio-{{ loop.index }}">
-              &nbsp;
+                &nbsp;
+              <span class="visually-hidden">{{ user.name }}</span>
+        
             </label>
           </div>
         </td>

--- a/app/views/patterns/make-an-enquiry.html
+++ b/app/views/patterns/make-an-enquiry.html
@@ -38,22 +38,22 @@ Make an enquiry - Home Office design system
       <div class="example example-images confirmation details-margin-btm">
         <form>
           <div class="form-group">
-            <h3 class="govuk-heading-m" style="margin-bottom:20px;margin-top:1em;">Your enquiry</h3>
-            <label class="govuk-label" for="textarea">
+            <h2 class="govuk-heading-m" style="margin-bottom:20px; margin-top:1em;">Your enquiry</h2>
+            <label class="govuk-label" for="more-detail" id="more-detail-hint">
               Details 
             </label>
             <textarea class="govuk-textarea govuk-input--width-30" id="more-detail"  name="more-detail" rows="4" aria-describedby="more-detail-hint"></textarea>
           </div>
 
           <div class="form-group">
-            <h3 class="govuk-heading-m" style="margin-bottom:20px;margin-top:1em;">Your details so we can contact you</h3>
+            <h2 class="govuk-heading-m" style="margin-bottom:20px;margin-top:1em;">Your details so we can contact you</h2>
             <div class="govuk-form-group">
-              <label class="govuk-label" for="width-20">Full name</label>
-              <input class="govuk-input govuk-!-width-two-thirds" id="width-20" name="width-20" type="text">
+              <label class="govuk-label" for="name">Full name</label>
+              <input class="govuk-input govuk-!-width-two-thirds" id="name" name="name" type="text">
             </div>
             <div class="govuk-form-group">
-              <label class="govuk-label" for="width-20">Email address</label>
-              <input class="govuk-input govuk-!-width-two-thirds" id="width-20" name="width-20" type="text">
+              <label class="govuk-label" for="email">Email address</label>
+              <input class="govuk-input govuk-!-width-two-thirds" id="email" name="email" type="text">
             </div>
           </div>
           <div class="govuk-grid-row">


### PR DESCRIPTION
What's been done:

**Make an enquiry**
-  Example form now has labels attached to the field inputs

**Buttons**
- All buttons are now using <button> mark-up

**Highlight search results**
- Discussion with Yacoob and Atlas designers has led to the recommendation that including the highlighted words for screen readers might be more of a hindrance than a benefit. For now, they serve as a visual aid in some circumstances. Guidance will be added to the component to suggest the implementation of them are considered very carefully depending on the context of the service.
 
**Table-multi select**
- Checkboxes now have labels 
- The screen reader will now read out "clicked" and "un-clicked"