### PR TITLE
Content removed

### DIFF
--- a/app/views/styles/colour.html
+++ b/app/views/styles/colour.html
@@ -326,7 +326,6 @@ Colour - Home Office design system
         <h2 class="govuk-heading-l" style="margin-top: 2em;"">Accessibility</h2>
         <p>Text and background colours need to meet the minimum AA contrast ratios specified by <a href="https://www.w3.org/TR/WCAG21/#contrast-enhanced">Web Content Accessibility Guidelines (WCAG) 2.1</a>.</p>
         <p>All of our secondary colours were assessed in a tool built to test colour contrast compliance with the WCAG. These are the colours combinations that passed.</p>
-        <p>These combinations are used in the Home Office design system. They should only be used for graphics and visualisation.</p>
       </section>
 
       <!-- BACKGROUND COMBINATIONS -->


### PR DESCRIPTION
Sentence removed as it was contradictory and could cause confusion:

> These combinations are used in the Home Office design system. They should only be used for graphics and visualisation.