### PR TITLE
Updated and simplified colour page

### DIFF
--- a/app/views/styles/colour.html
+++ b/app/views/styles/colour.html
@@ -16,84 +16,37 @@ Colour - Home Office design system
 
       <span class="govuk-caption-xl">Styles</span>
       <h1 class="heading-section">Colour</h1>
-      <p class="govuk-body-l">Colour is a powerful means of drawing a user’s attention or giving focus to an element. Colour must be used with care and discretion, backed up by usability and accessibility testing. In the Home Office design system we use colour to draw attention to actions, links and to the Home Office design style. It is never used for ‘decoration’.</p>
-      <p class="govuk-body-l">Always ask the central design team (<a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a>) for advice.</p>
+      <p class="govuk-body-l">Always use the Home Office colour palette when you're designing and building internal services and products. For public facing and transactional sites use the <a href="https://design-system.service.gov.uk/styles/colour/">GOV.UK colour palette</a>.</p>
+      <p class="govuk-body-l">Ask <a href="mailto:design@digital.homeoffice.gov.uk">design@digital.homeoffice.gov.uk</a> if you have any questions.</p>
 
       <!-- PRIMARY -->
 
       <section class="colour-swatch-wrapper">
-        <h2 class="govuk-heading-l" style="margin-top: 1em; margin-bottom: 0.5em;">Primary colours</h2>
+        <h2 class="govuk-heading-l" style="margin-top: 1em; margin-bottom: 0.5em;">Main colours</h2>
 
-        <h3 class="govuk-heading-m">Text</h3>
+        <h3 class="govuk-heading-m">Brand colour</h3>
         <div class="colour-swatch">
-          <span class="app-swatch" style="background-color:#0b0c0c"></span>
+          <span class="app-swatch" style="background-color:#8F23B3"></span>
           <div class="hex">
-            #0B0C0C
+            #8f23b3
           </div>
           <div class="colour-info">
-            Black is used for headings and body content
+            <p>Purple is the Home Office's brand colour. This doesn't mean you should use it as the dominant colour in a digital interface.</p>
+
+<p>Overusing the purple can make content hard to read on screen, particularly on services that are designed to be used for long periods of time.</p>
+
+<p>Home Office purple works best in digital interfaces when it's just used for the Home Office logo and sparingly used as a keyline or accent.</p>
           </div>
         </div>
 
-        <div class="colour-swatch">
-            <span class="app-swatch" style="background-color:#4E5455"></span>
-            <div class="hex">
-              #4E5455
-            </div>
-            <div class="colour-info">
-              Secondary text colour
-            </div>
-        </div>
-
-        <h3 class="govuk-heading-m" style="margin-top: 1em;">Links</h3>
-        <div class="colour-swatch">
-            <span class="app-swatch" style="background-color:#1D70B8"></span>
-            <div class="hex">
-              #1D70B8
-            </div>
-            <div class="colour-info">
-              Link colour
-            </div>
-        </div>
-
-        <div class="colour-swatch">
-            <span class="app-swatch" style="background-color:#003078"></span>
-            <div class="hex">
-              #003078
-            </div>
-            <div class="colour-info">
-              Link hover colour
-            </div>
-        </div>
-
-        <div class="colour-swatch">
-            <span class="app-swatch" style="background-color:#4C2C92"></span>
-            <div class="hex">
-              #4C2C92
-            </div>
-            <div class="colour-info">
-              Link visited colour
-            </div>
-        </div>
-
-        <div class="colour-swatch">
-            <span class="app-swatch" style="background-color:#0B0C0C"></span>
-            <div class="hex">
-              #0B0C0C
-            </div>
-            <div class="colour-info">
-              Link active colour
-            </div>
-        </div>
-
-        <h3 class="govuk-heading-m" style="margin-top: 1em;">Content background</h3>
+        <h3 class="govuk-heading-m" style="margin-top: 1em;">Page background</h3>
         <div class="colour-swatch">
           <span class="app-swatch" style="background-color:#F1F1F1; border:1px solid #CBCBCB;"></span>
           <div class="hex">
-            #F1F1F1
+            #f1f1f1
           </div>
           <div class="colour-info">
-            Light grey is used as the content background colour on internal services to minimise eye strain caused by high contrast user interfaces. It also supports readability for those who have dyslexia. Only the primary text and link colours can be used on this background
+            Use light grey as the page background colour on internal services to minimise eye strain caused by high-contrast user interfaces. It's also better for readability for those with dyslexia.
           </div>
         </div>
 
@@ -101,238 +54,36 @@ Colour - Home Office design system
         <div class="colour-swatch">
           <span class="app-swatch" style="background-color:#CBCBCB;"></span>
           <div class="hex">
-            #CBCBCB
+            #cbcbcb
           </div>
           <div class="colour-info">
-            This colour is used for borders and to help define elements where needed.
+            Use mid-grey for borders and to help define elements where needed.
           </div>
         </div>
 
-        <div class="colour-swatch">
-            <span class="app-swatch" style="background-color:#0B0C0C;"></span>
-            <div class="hex">
-              #0B0C0C
-            </div>
-            <div class="colour-info">
-              Input border colour
-            </div>
-          </div>
+        <h3 class="govuk-heading-m" style="margin-top: 1em;">Text and links</h3>
 
-        <h3 class="govuk-heading-m" style="margin-top: 1em;">Focus state</h3>
-        <div class="colour-swatch">
-          <span class="app-swatch" style="background-color:#FFDD00;"></span>
-          <div class="hex">
-            #FFDD00
-          </div>
-          <div class="colour-info">
-            Focus colour
-          </div>
-        </div>
+          <p>Use the <a href="https://design-system.service.gov.uk/styles/colour/">GOV.UK colours</a> for text and links as these meet accessibility standards when used with the Home Office page background.</p>
 
-        <div class="colour-swatch">
-            <span class="app-swatch" style="background-color:#0B0C0C;"></span>
-            <div class="hex">
-              #0B0C0C
-            </div>
-            <div class="colour-info">
-              Focus text colour
-            </div>
-          </div>
 
-        <h3 class="govuk-heading-m" style="margin-top: 1em;">Error state</h3>
-        <div class="colour-swatch">
-          <span class="app-swatch" style="background-color:#D4351C;"></span>
-          <div class="hex">
-            #D4351C
-          </div>
-          <div class="colour-info">
-            Error colour
-          </div>
-        </div>
 
-        <h3 class="govuk-heading-m" style="margin-top: 1em;">Brand colour</h3>
-        <div class="colour-swatch">
-          <span class="app-swatch" style="background-color:#8F23B3;"></span>
-          <div class="hex">
-            #8F23B3
-          </div>
-          <div class="colour-info">
-            Purple is the Home Office’s brand colour. This doesn’t mean it should be used as the dominant colour in a digital interface. Overuse of the purple can make contenthard to read on screen, particularly on services that are designed to be used for long periods of time. Home Office purple works best when reserved for the Home Office logo or sparingly used as a keyline or accent.
-          </div>
-        </div>
+
       </section>
 
       <!-- SECONDARY -->
 
       <section class="colour-swatch-wrapper">
-        <h2 class="govuk-heading-l" style="margin-top: 2em;">Secondary colours</h2>
-        <p>Use these colours for graphs and supporting material. Check with the central design team (designops@digital.homeoffice.gov.uk) for advice. If you need to use tints of this palette, use either 25% or 50%.</p>
+        <h2 class="govuk-heading-l" style="margin-top: 2em;">Extra colours</h2>
+        <p>You can use the <a href="https://design-system.service.gov.uk/styles/colour/">GOV.UK colour palette</a> alongside the main Home Office colours. Use them to create graphs and supporting materials. If you need to use tints of the palette, use either 25% or 50%.</p>
 
-        <div class="colour-swatch">
-          <span class="app-swatch" style="background-color:#882345"></span>
-          <div class="hex">
-            #882345
-          </div>
-          <div class="colour-info">
-            Maroon
-          </div>
-        </div>
 
-        <div class="colour-swatch">
-            <span class="app-swatch" style="background-color:#D4351C"></span>
-            <div class="hex">
-              #D4351C
-            </div>
-            <div class="colour-info">
-              Red
-            </div>
-        </div>
-
-        <div class="colour-swatch">
-            <span class="app-swatch" style="background-color:#EA5B5D"></span>
-            <div class="hex">
-              #EA5B5D
-            </div>
-            <div class="colour-info">
-              Pink
-            </div>
-        </div>
-
-        <div class="colour-swatch">
-            <span class="app-swatch" style="background-color:#F39728"></span>
-            <div class="hex">
-              #EE763B
-            </div>
-            <div class="colour-info">
-              Orange
-            </div>
-        </div>
-
-        <div class="colour-swatch">
-            <span class="app-swatch" style="background-color:#FCEA1D"></span>
-            <div class="hex">
-              #FCEA1D
-            </div>
-            <div class="colour-info">
-              Yellow
-            </div>
-        </div>
-
-        <div class="colour-swatch">
-            <span class="app-swatch" style="background-color:#3FA435"></span>
-            <div class="hex">
-              #3FA435
-            </div>
-            <div class="colour-info">
-              Green
-            </div>
-        </div>
-
-        <div class="colour-swatch">
-            <span class="app-swatch" style="background-color:#9A9D1F"></span>
-            <div class="hex">
-              #9A9D1F
-            </div>
-            <div class="colour-info">
-              Olive
-            </div>
-        </div>
-
-        <div class="colour-swatch">
-            <span class="app-swatch" style="background-color:#00747A"></span>
-            <div class="hex">
-              #00747A
-            </div>
-            <div class="colour-info">
-              Teal
-            </div>
-        </div>
-
-        <div class="colour-swatch">
-            <span class="app-swatch" style="background-color:#002664"></span>
-            <div class="hex">
-              #002664
-            </div>
-            <div class="colour-info">
-              Dark blue
-            </div>
-        </div>
-
-        <div class="colour-swatch">
-            <span class="app-swatch" style="background-color:#045EA4"></span>
-            <div class="hex">
-              #045EA4
-            </div>
-            <div class="colour-info">
-              Blue
-            </div>
-        </div>
-
-        <div class="colour-swatch">
-            <span class="app-swatch" style="background-color:#1EB8D7"></span>
-            <div class="hex">
-              #1EB8D7
-            </div>
-            <div class="colour-info">
-              Light blue
-            </div>
-        </div>
-
-        <div class="colour-swatch">
-            <span class="app-swatch" style="background-color:#858585"></span>
-            <div class="hex">
-              #858585
-            </div>
-            <div class="colour-info">
-              Dark grey
-            </div>
-        </div>
-
-        <div class="colour-swatch">
-            <span class="app-swatch" style="background-color:#B5B6B6"></span>
-            <div class="hex">
-              #B5B6B6
-            </div>
-            <div class="colour-info">
-              Grey
-            </div>
-        </div>
-
-        <div class="colour-swatch">
-            <span class="app-swatch" style="background-color:#E6E6E6"></span>
-            <div class="hex">
-              #E6E6E6
-            </div>
-            <div class="colour-info">
-              Light grey
-            </div>
-        </div>
-
-        <div class="colour-swatch">
-            <span class="app-swatch" style="background-color:#F8F8F7; border:1px solid #CBCBCB;"></span>
-            <div class="hex">
-              #F8F8F7
-            </div>
-            <div class="colour-info">
-              Off white
-            </div>
-        </div>
-
-      </section>
-
-      <!-- ACCESSIBILITY -->
-
-      <section class="colour-swatch-wrapper">
-        <h2 class="govuk-heading-l" style="margin-top: 2em;"">Accessibility</h2>
-        <p>Text and background colours need to meet the minimum AA contrast ratios specified by <a href="https://www.w3.org/TR/WCAG21/#contrast-enhanced">Web Content Accessibility Guidelines (WCAG) 2.1</a>.</p>
-        <p>All of our secondary colours were assessed in a tool built to test colour contrast compliance with the WCAG. These are the colours combinations that passed.</p>
       </section>
 
       <!-- BACKGROUND COMBINATIONS -->
 
       <section class="colour-swatch-wrapper">
         <h2 class=" heading-small" style="margin-top: 2em;">Accessible text and background combinations</h2>
-        <p>Colour alone should never be used to convey information. You must also describe the information you are trying to convey.</p>
+        <p>You should never use colour as the only way to convey information. You must also describe the information you're trying to convey. Always test the text and background colours to make sure they meet the minimum AA contrast ratios specified by <a href="https://www.w3.org/TR/WCAG21/#contrast-minimum">Web Content Accessibility Guidelines (WCAG) 2.1</a>. Below are the colour combinations that pass.</p>
 
 
         <div class="govuk-grid-row">
@@ -340,107 +91,57 @@ Colour - Home Office design system
           <div class="govuk-grid-column-one-half">
 
             <div class="colour-swatch">
-              <span class="app-swatch" style="background-color:#FCEA1D">
-                <span style="color:#0B0C0C;">A</span>
+              <span class="app-swatch" style="background-color:#0b0c0c">
+                <span style="color:#ffffff;">A</span>
               </span>
               <div class="colour-info">
-                Background: #FCEA1D<br>
-                Foreground: #0B0C0C
+                Background: #0b0c0c<br>
+                Foreground: #ffffff
               </div>
             </div>
 
             <div class="colour-swatch">
-              <span class="app-swatch" style="background-color:#F8F8F7;  border:1px solid #CBCBCB;">
-                <span style="color:#0B0C0C;">A</span>
+              <span class="app-swatch" style="background-color:#ffffff;  border:1px solid #CBCBCB;">
+                <span style="color:#0b0c0c;">A</span>
               </span>
               <div class="colour-info">
-                Background: #F8F8F7<br>
-                Foreground: #0B0C0C
+                Background: #ffffff<br>
+                Foreground: #0b0c0c
               </div>
             </div>
 
             <div class="colour-swatch">
-              <span class="app-swatch" style="background-color:#E6E6E6;  border:1px solid #CBCBCB;">
-                <span style="color:#0B0C0C;">A</span>
+              <span class="app-swatch" style="background-color:#cbcbcb;  border:1px solid #CBCBCB;">
+                <span style="color:#0b0c0c;">A</span>
               </span>
               <div class="colour-info">
-                Background: #E6E6E6<br>
-                Foreground: #0B0C0C
+                Background: #cbcbcb<br>
+                Foreground: #0b0c0c
               </div>
             </div>
 
             <div class="colour-swatch">
-              <span class="app-swatch" style="background-color:#3FA435;">
-                <span style="color:#FFFFFF;">A</span>
+              <span class="app-swatch" style="background-color:#00703c;">
+                <span style="color:#ffffff;">A</span>
               </span>
               <div class="colour-info">
-                Background: #3FA435<br>
+                Background: #00703c<br>
                 Foreground: #FFFFFF
               </div>
             </div>
 
             <div class="colour-swatch">
-              <span class="app-swatch" style="background-color:#00747A;">
-                <span style="color:#FFFFFF;">A</span>
+              <span class="app-swatch" style="background-color:#1d70b8;">
+                <span style="color:#ffffff;">A</span>
               </span>
               <div class="colour-info">
-                Background: #00747A<br>
+                Background: #1d70b8<br>
                 Foreground: #FFFFFF
               </div>
             </div>
           </div>
 
-          <div class="govuk-grid-column-one-half">
-            <div class="colour-swatch">
-                <span class="app-swatch" style="background-color:#1D70B8;">
-                  <span style="color:#FFFFFF;">A</span>
-                </span>
-                <div class="colour-info">
-                  Background: #1D70B8<br>
-                  Foreground: #FFFFFF
-                </div>
-              </div>
 
-              <div class="colour-swatch">
-                <span class="app-swatch" style="background-color:#0B0C0C;">
-                  <span style="color:#FFFFFF;">A</span>
-                </span>
-                <div class="colour-info">
-                  Background: #0B0C0C<br>
-                  Foreground: #FFFFFF
-                </div>
-              </div>
-
-              <div class="colour-swatch">
-                <span class="app-swatch" style="background-color:#882345;">
-                  <span style="color:#FFFFFF;">A</span>
-                </span>
-                <div class="colour-info">
-                  Background: #882345<br>
-                  Foreground: #FFFFFF
-                </div>
-              </div>
-
-              <div class="colour-swatch">
-                <span class="app-swatch" style="background-color:#002664;">
-                  <span style="color:#FFFFFF;">A</span>
-                </span>
-                <div class="colour-info">
-                  Background: #002664<br>
-                  Foreground: #FFFFFF
-                </div>
-              </div>
-
-              <div class="colour-swatch">
-                <span class="app-swatch" style="background-color:#858585;">
-                  <span style="color:#FFFFFF;">A</span>
-                </span>
-                <div class="colour-info">
-                  Background: #858585<br>
-                  Foreground: #FFFFFF
-                </div>
-              </div>
-          </div>
 
         </div>
 


### PR DESCRIPTION
Current colour palette  is confusing:
1. duplicates GOV.UK colours in some areas
2. uses DDaT branding colours but not accessible with grey background 

This branch will highlight HO colours not used in GOV.UK and refer to GOV.UK as extended palette.