### PR TITLE
docs: Replace reference to NotGovUK

### DIFF
--- a/apps/docs/src/common/pages/components.tsx
+++ b/apps/docs/src/common/pages/components.tsx
@@ -6,7 +6,7 @@ import { DocsPage } from '@not-govuk/docs-components';
 import { stories as subpages } from '../component-stories';
 
 export const title = 'Components';
-const description = 'The components provided in NotGovUK';
+const description = 'The components provided in the Home Office Design System';
 
 const Page: FC<PageProps> = ({ location }) => {
   const nameParam = 'name';


### PR DESCRIPTION
Replaces a reference to NotGovUK (with HODS) in a page description.