### PR TITLE
docs: Import side navigation into sub-pages

### DIFF
--- a/apps/docs/src/common/pages/accessibility.tsx
+++ b/apps/docs/src/common/pages/accessibility.tsx
@@ -3,19 +3,8 @@ import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
 import { A, NavigationMenu } from '@not-govuk/components';
 
-export const title = 'Accessibility';
-const description = 'Information on how to ensure your service is accessible'
-
-const Page: FC<PageProps> = ({ location }) => (
-  <div className="govuk-grid-row">
-    <Helmet>
-      <title>{title} - Home Office Design System</title>
-      <meta name="description" content={description} />
-      <meta name="og:title" content={title} />
-      <meta name="og:description" content={description} />
-      <meta name="og:article:section" content={title} />
-    </Helmet>
-    <div className="govuk-grid-column-one-quarter">
+export const menu = (
+  <Fragment>
     <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
       <NavigationMenu items={[
         {
@@ -147,6 +136,23 @@ const Page: FC<PageProps> = ({ location }) => (
               text: 'Guidance, tools and further reading'
             }
           ]} />
+  </Fragment>
+);
+
+export const title = 'Accessibility';
+const description = 'Information on how to ensure your service is accessible'
+
+const Page: FC<PageProps> = ({ location }) => (
+  <div className="govuk-grid-row">
+    <Helmet>
+      <title>{title} - Home Office Design System</title>
+      <meta name="description" content={description} />
+      <meta name="og:title" content={title} />
+      <meta name="og:description" content={description} />
+      <meta name="og:article:section" content={title} />
+    </Helmet>
+    <div className="govuk-grid-column-one-quarter">
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>Accessibility</h1>

--- a/apps/docs/src/common/pages/accessibility/audio-and-video.tsx
+++ b/apps/docs/src/common/pages/accessibility/audio-and-video.tsx
@@ -1,7 +1,8 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../accessibility'
 
 export const title = 'Audio and video';
 const description = 'Accessibility guidance for audio and video content';
@@ -17,137 +18,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/headings',
-        text: 'Headings'
-      },
-      {
-        href: '/accessibility/layout-typography',
-        text: 'Layout and typography'
-      },
-      {
-        href: '/accessibility/links',
-        text: 'Links'
-      },
-      {
-        href: '/accessibility/navigation',
-        text: 'Navigation'
-      },
-      {
-        href: '/accessibility/tables',
-        text: 'Tables'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Interactivity</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/error-messages',
-        text: 'Error messages'
-      },
-      {
-        href: '/accessibility/forms',
-        text: 'Forms'
-      },
-      {
-        href: '/accessibility/keyboard',
-        text: 'Keyboard basics'
-      },
-      {
-        href: '/accessibility/keyboard/tab-navigation',
-        text: '- Tab navigation'
-      },
-      {
-        href: '/accessibility/keyboard/focus',
-        text: '- Focus'
-      },
-      {
-        href: '/accessibility/keyboard/skip-to-content',
-        text: '- Skip to content links'
-      },
-      {
-        href: '/accessibility/keyboard/character-key-shortcuts',
-        text: '- Character key shortcuts'
-      },
-      {
-        href: '/accessibility/keyboard/pointer-gestures',
-        text: '- Pointer gestures'
-      },
-      {
-        href: '/accessibility/notifications',
-        text: 'Notifications'
-      },
-      {
-        href: '/accessibility/forms/keyboard',
-        text: '- Keyboard'
-      },
-      {
-        href: '/accessibility/timeouts',
-        text: 'Timeouts'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Written content</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/inclusive-language',
-          text: 'Inclusive language'
-        },
-        {
-          href: '/accessibility/readability',
-          text: 'Readability'
-        }
-      ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Providing alternatives</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/audio-and-video',
-          text: 'Audio and video'
-        },
-        {
-          href: '/accessibility/colour-and-contrast',
-          text: 'Colour and contrast'
-        },
-        {
-          href: '/accessibility/images',
-          text: 'Images'
-        },
-        {
-          href: '/accessibility/moving-and-flashing-content',
-          text: 'Moving and flashing content'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/standard',
-            text: 'Accessibility Standard'
-          },
-          {
-            href: '/accessibility/standard/perceivable',
-            text: '- Perceivable'
-          },
-          {
-            href: '/accessibility/standard/operable',
-            text: '- Operable'
-          },
-          {
-            href: '/accessibility/standard/understandable',
-            text: '- Understandable'
-          },
-          {
-            href: '/accessibility/standard/robust',
-            text: '- Robust'
-          },
-          {
-            href: '/accessibility/standard/meet-user-needs',
-            text: '- Meet user needs'
-          },
-          {
-            href: '/accessibility/resources',
-            text: 'Guidance, tools and further reading'
-          }
-        ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>

--- a/apps/docs/src/common/pages/accessibility/colour-and-contrast.tsx
+++ b/apps/docs/src/common/pages/accessibility/colour-and-contrast.tsx
@@ -1,7 +1,8 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../accessibility'
 
 const linksImage01 = require('../../../../assets/images/accessibility/colour-contrast.png').default;
 
@@ -19,136 +20,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/headings',
-        text: 'Headings'
-      },
-      {
-        href: '/accessibility/layout-typography',
-        text: 'Layout and typography'
-      },      {
-        href: '/accessibility/links',
-        text: 'Links'
-      },
-      {
-        href: '/accessibility/navigation',
-        text: 'Navigation'
-      },
-      {
-        href: '/accessibility/tables',
-        text: 'Tables'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Interactivity</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/error-messages',
-        text: 'Error messages'
-      },
-      {
-        href: '/accessibility/forms',
-        text: 'Forms'
-      },
-      {
-        href: '/accessibility/keyboard',
-        text: 'Keyboard basics'
-      },
-      {
-        href: '/accessibility/keyboard/tab-navigation',
-        text: '- Tab navigation'
-      },
-      {
-        href: '/accessibility/keyboard/focus',
-        text: '- Focus'
-      },
-      {
-        href: '/accessibility/keyboard/skip-to-content',
-        text: '- Skip to content links'
-      },
-      {
-        href: '/accessibility/keyboard/character-key-shortcuts',
-        text: '- Character key shortcuts'
-      },
-      {
-        href: '/accessibility/keyboard/pointer-gestures',
-        text: '- Pointer gestures'
-      },
-      {
-        href: '/accessibility/notifications',
-        text: 'Notifications'
-      },
-      {
-        href: '/accessibility/forms/keyboard',
-        text: '- Keyboard'
-      },
-      {
-        href: '/accessibility/timeouts',
-        text: 'Timeouts'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Written content</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/inclusive-language',
-          text: 'Inclusive language'
-        },
-        {
-          href: '/accessibility/readability',
-          text: 'Readability'
-        }
-      ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Providing alternatives</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/audio-and-video',
-          text: 'Audio and video'
-        },
-        {
-          href: '/accessibility/colour-and-contrast',
-          text: 'Colour and contrast'
-        },
-        {
-          href: '/accessibility/images',
-          text: 'Images'
-        },
-        {
-          href: '/accessibility/moving-and-flashing-content',
-          text: 'Moving and flashing content'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/standard',
-            text: 'Accessibility Standard'
-          },
-          {
-            href: '/accessibility/standard/perceivable',
-            text: '- Perceivable'
-          },
-          {
-            href: '/accessibility/standard/operable',
-            text: '- Operable'
-          },
-          {
-            href: '/accessibility/standard/understandable',
-            text: '- Understandable'
-          },
-          {
-            href: '/accessibility/standard/robust',
-            text: '- Robust'
-          },
-          {
-            href: '/accessibility/standard/meet-user-needs',
-            text: '- Meet user needs'
-          },
-          {
-            href: '/accessibility/resources',
-            text: 'Guidance, tools and further reading'
-          }
-        ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>

--- a/apps/docs/src/common/pages/accessibility/error-messages.tsx
+++ b/apps/docs/src/common/pages/accessibility/error-messages.tsx
@@ -1,7 +1,8 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../accessibility'
 
 export const title = 'Error messages';
 const description = 'Accessibility guidance for error messages';
@@ -17,137 +18,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/headings',
-        text: 'Headings'
-      },
-      {
-        href: '/accessibility/layout-typography',
-        text: 'Layout and typography'
-      },
-      {
-        href: '/accessibility/links',
-        text: 'Links'
-      },
-      {
-        href: '/accessibility/navigation',
-        text: 'Navigation'
-      },
-      {
-        href: '/accessibility/tables',
-        text: 'Tables'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Interactivity</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/error-messages',
-        text: 'Error messages'
-      },
-      {
-        href: '/accessibility/forms',
-        text: 'Forms'
-      },
-      {
-        href: '/accessibility/keyboard',
-        text: 'Keyboard basics'
-      },
-      {
-        href: '/accessibility/keyboard/tab-navigation',
-        text: '- Tab navigation'
-      },
-      {
-        href: '/accessibility/keyboard/focus',
-        text: '- Focus'
-      },
-      {
-        href: '/accessibility/keyboard/skip-to-content',
-        text: '- Skip to content links'
-      },
-      {
-        href: '/accessibility/keyboard/character-key-shortcuts',
-        text: '- Character key shortcuts'
-      },
-      {
-        href: '/accessibility/keyboard/pointer-gestures',
-        text: '- Pointer gestures'
-      },
-      {
-        href: '/accessibility/notifications',
-        text: 'Notifications'
-      },
-      {
-        href: '/accessibility/forms/keyboard',
-        text: '- Keyboard'
-      },
-      {
-        href: '/accessibility/timeouts',
-        text: 'Timeouts'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Written content</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/inclusive-language',
-          text: 'Inclusive language'
-        },
-        {
-          href: '/accessibility/readability',
-          text: 'Readability'
-        }
-      ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Providing alternatives</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/audio-and-video',
-          text: 'Audio and video'
-        },
-        {
-          href: '/accessibility/colour-and-contrast',
-          text: 'Colour and contrast'
-        },
-        {
-          href: '/accessibility/images',
-          text: 'Images'
-        },
-        {
-          href: '/accessibility/moving-and-flashing-content',
-          text: 'Moving and flashing content'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/standard',
-            text: 'Accessibility Standard'
-          },
-          {
-            href: '/accessibility/standard/perceivable',
-            text: '- Perceivable'
-          },
-          {
-            href: '/accessibility/standard/operable',
-            text: '- Operable'
-          },
-          {
-            href: '/accessibility/standard/understandable',
-            text: '- Understandable'
-          },
-          {
-            href: '/accessibility/standard/robust',
-            text: '- Robust'
-          },
-          {
-            href: '/accessibility/standard/meet-user-needs',
-            text: '- Meet user needs'
-          },
-          {
-            href: '/accessibility/resources',
-            text: 'Guidance, tools and further reading'
-          }
-        ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>

--- a/apps/docs/src/common/pages/accessibility/forms.tsx
+++ b/apps/docs/src/common/pages/accessibility/forms.tsx
@@ -1,7 +1,8 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../accessibility'
 
 export const title = 'Forms';
 const description = 'Accessibility guidance for forms';
@@ -17,137 +18,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/headings',
-        text: 'Headings'
-      },
-      {
-        href: '/accessibility/layout-typography',
-        text: 'Layout and typography'
-      },
-      {
-        href: '/accessibility/links',
-        text: 'Links'
-      },
-      {
-        href: '/accessibility/navigation',
-        text: 'Navigation'
-      },
-      {
-        href: '/accessibility/tables',
-        text: 'Tables'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Interactivity</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/error-messages',
-        text: 'Error messages'
-      },
-      {
-        href: '/accessibility/forms',
-        text: 'Forms'
-      },
-      {
-        href: '/accessibility/keyboard',
-        text: 'Keyboard basics'
-      },
-      {
-        href: '/accessibility/keyboard/tab-navigation',
-        text: '- Tab navigation'
-      },
-      {
-        href: '/accessibility/keyboard/focus',
-        text: '- Focus'
-      },
-      {
-        href: '/accessibility/keyboard/skip-to-content',
-        text: '- Skip to content links'
-      },
-      {
-        href: '/accessibility/keyboard/character-key-shortcuts',
-        text: '- Character key shortcuts'
-      },
-      {
-        href: '/accessibility/keyboard/pointer-gestures',
-        text: '- Pointer gestures'
-      },
-      {
-        href: '/accessibility/notifications',
-        text: 'Notifications'
-      },
-      {
-        href: '/accessibility/forms/keyboard',
-        text: '- Keyboard'
-      },
-      {
-        href: '/accessibility/timeouts',
-        text: 'Timeouts'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Written content</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/inclusive-language',
-          text: 'Inclusive language'
-        },
-        {
-          href: '/accessibility/readability',
-          text: 'Readability'
-        },
-      ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Providing alternatives</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/audio-and-video',
-          text: 'Audio and video'
-        },
-        {
-          href: '/accessibility/colour-and-contrast',
-          text: 'Colour and contrast'
-        },
-        {
-          href: '/accessibility/images',
-          text: 'Images'
-        },
-        {
-          href: '/accessibility/moving-and-flashing-content',
-          text: 'Moving and flashing content'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/standard',
-            text: 'Accessibility Standard'
-          },
-          {
-            href: '/accessibility/standard/perceivable',
-            text: '- Perceivable'
-          },
-          {
-            href: '/accessibility/standard/operable',
-            text: '- Operable'
-          },
-          {
-            href: '/accessibility/standard/understandable',
-            text: '- Understandable'
-          },
-          {
-            href: '/accessibility/standard/robust',
-            text: '- Robust'
-          },
-          {
-            href: '/accessibility/standard/meet-user-needs',
-            text: '- Meet user needs'
-          },
-          {
-            href: '/accessibility/resources',
-            text: 'Guidance, tools and further reading'
-          }
-        ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>

--- a/apps/docs/src/common/pages/accessibility/forms/keyboard.tsx
+++ b/apps/docs/src/common/pages/accessibility/forms/keyboard.tsx
@@ -1,13 +1,14 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
-
-const formskeyboardImage = require('../../../../../assets/images/accessibility/forms-keyboard.png').default;
+import { A } from '@not-govuk/components';
+import { menu } from '../../accessibility'
 
 export const title = 'Keyboard';
 const description = 'Accessibility guidance for forms';
 export const section = 'Accessibility';
+
+const formskeyboardImage = require('../../../../../assets/images/accessibility/forms-keyboard.png').default;
 
 const Page: FC<PageProps> = ({ location }) => (
   <div className="govuk-grid-row">
@@ -19,133 +20,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/links',
-        text: 'Links'
-      },
-      {
-        href: '/accessibility/navigation',
-        text: 'Navigation'
-      },
-      {
-        href: '/accessibility/tables',
-        text: 'Tables'
-      },
-      {
-        href: '/accessibility/headings',
-        text: 'Headings'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Interactivity</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/error-messages',
-        text: 'Error messages'
-      },
-      {
-        href: '/accessibility/notifications',
-        text: 'Notifications'
-      },
-      {
-        href: '/accessibility/keyboard',
-        text: 'Keyboard basics'
-      },
-      {
-        href: '/accessibility/keyboard/tab-navigation',
-        text: '- Tab navigation'
-      },
-      {
-        href: '/accessibility/keyboard/focus',
-        text: '- Focus'
-      },
-      {
-        href: '/accessibility/keyboard/skip-to-content',
-        text: '- Skip to content links'
-      },
-      {
-        href: '/accessibility/keyboard/character-key-shortcuts',
-        text: '- Character key shortcuts'
-      },
-      {
-        href: '/accessibility/keyboard/pointer-gestures',
-        text: '- Pointer gestures'
-      },
-      {
-        href: '/accessibility/forms',
-        text: 'Forms'
-      },
-      {
-        href: '/accessibility/forms/keyboard',
-        text: '- Keyboard'
-      },
-      {
-        href: '/accessibility/timeouts',
-        text: 'Timeouts'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Written content</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/inclusive-language',
-          text: 'Inclusive language'
-        },
-        {
-          href: '/accessibility/readability',
-          text: 'Readability'
-        },
-      ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Providing alternatives</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/audio-and-video',
-          text: 'Audio and video'
-        },
-        {
-          href: '/accessibility/colour-and-contrast',
-          text: 'Colour and contrast'
-        },
-        {
-          href: '/accessibility/images',
-          text: 'Images'
-        },
-        {
-          href: '/accessibility/moving-and-flashing-content',
-          text: 'Moving and flashing content'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/standard',
-            text: 'Accessibility Standard'
-          },
-          {
-            href: '/accessibility/standard/perceivable',
-            text: '- Perceivable'
-          },
-          {
-            href: '/accessibility/standard/operable',
-            text: '- Operable'
-          },
-          {
-            href: '/accessibility/standard/understandable',
-            text: '- Understandable'
-          },
-          {
-            href: '/accessibility/standard/robust',
-            text: '- Robust'
-          },
-          {
-            href: '/accessibility/standard/meet-user-needs',
-            text: '- Meet user needs'
-          },
-          {
-            href: '/accessibility/resources',
-            text: 'Guidance, tools and further reading'
-          }
-        ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
 

--- a/apps/docs/src/common/pages/accessibility/headings.tsx
+++ b/apps/docs/src/common/pages/accessibility/headings.tsx
@@ -1,7 +1,8 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../accessibility'
 
 const headingImage = require('../../../../assets/images/accessibility/heading-hierarchy.png').default;
 
@@ -19,137 +20,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/headings',
-        text: 'Headings'
-      },
-      {
-        href: '/accessibility/layout-typography',
-        text: 'Layout and typography'
-      },
-      {
-        href: '/accessibility/links',
-        text: 'Links'
-      },
-      {
-        href: '/accessibility/navigation',
-        text: 'Navigation'
-      },
-      {
-        href: '/accessibility/tables',
-        text: 'Tables'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Interactivity</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/error-messages',
-        text: 'Error messages'
-      },
-      {
-        href: '/accessibility/forms',
-        text: 'Forms'
-      },
-      {
-        href: '/accessibility/keyboard',
-        text: 'Keyboard basics'
-      },
-      {
-        href: '/accessibility/keyboard/tab-navigation',
-        text: '- Tab navigation'
-      },
-      {
-        href: '/accessibility/keyboard/focus',
-        text: '- Focus'
-      },
-      {
-        href: '/accessibility/keyboard/skip-to-content',
-        text: '- Skip to content links'
-      },
-      {
-        href: '/accessibility/keyboard/character-key-shortcuts',
-        text: '- Character key shortcuts'
-      },
-      {
-        href: '/accessibility/keyboard/pointer-gestures',
-        text: '- Pointer gestures'
-      },
-      {
-        href: '/accessibility/notifications',
-        text: 'Notifications'
-      },
-      {
-        href: '/accessibility/forms/keyboard',
-        text: '- Keyboard'
-      },
-      {
-        href: '/accessibility/timeouts',
-        text: 'Timeouts'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Written content</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/inclusive-language',
-          text: 'Inclusive language'
-        },
-        {
-          href: '/accessibility/readability',
-          text: 'Readability'
-        }
-      ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Providing alternatives</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/audio-and-video',
-          text: 'Audio and video'
-        },
-        {
-          href: '/accessibility/colour-and-contrast',
-          text: 'Colour and contrast'
-        },
-        {
-          href: '/accessibility/images',
-          text: 'Images'
-        },
-        {
-          href: '/accessibility/moving-and-flashing-content',
-          text: 'Moving and flashing content'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/standard',
-            text: 'Accessibility Standard'
-          },
-          {
-            href: '/accessibility/standard/perceivable',
-            text: '- Perceivable'
-          },
-          {
-            href: '/accessibility/standard/operable',
-            text: '- Operable'
-          },
-          {
-            href: '/accessibility/standard/understandable',
-            text: '- Understandable'
-          },
-          {
-            href: '/accessibility/standard/robust',
-            text: '- Robust'
-          },
-          {
-            href: '/accessibility/standard/meet-user-needs',
-            text: '- Meet user needs'
-          },
-          {
-            href: '/accessibility/resources',
-            text: 'Guidance, tools and further reading'
-          }
-        ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>

--- a/apps/docs/src/common/pages/accessibility/images.tsx
+++ b/apps/docs/src/common/pages/accessibility/images.tsx
@@ -1,7 +1,8 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../accessibility'
 
 const applyImageInline = require('../../../../assets/images/patterns/image-guidance-inline.svg').default;
 
@@ -19,137 +20,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/headings',
-        text: 'Headings'
-      },
-      {
-        href: '/accessibility/layout-typography',
-        text: 'Layout and typography'
-      },
-      {
-        href: '/accessibility/links',
-        text: 'Links'
-      },
-      {
-        href: '/accessibility/navigation',
-        text: 'Navigation'
-      },
-      {
-        href: '/accessibility/tables',
-        text: 'Tables'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Interactivity</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/error-messages',
-        text: 'Error messages'
-      },
-      {
-        href: '/accessibility/forms',
-        text: 'Forms'
-      },
-      {
-        href: '/accessibility/keyboard',
-        text: 'Keyboard basics'
-      },
-      {
-        href: '/accessibility/keyboard/tab-navigation',
-        text: '- Tab navigation'
-      },
-      {
-        href: '/accessibility/keyboard/focus',
-        text: '- Focus'
-      },
-      {
-        href: '/accessibility/keyboard/skip-to-content',
-        text: '- Skip to content links'
-      },
-      {
-        href: '/accessibility/keyboard/character-key-shortcuts',
-        text: '- Character key shortcuts'
-      },
-      {
-        href: '/accessibility/keyboard/pointer-gestures',
-        text: '- Pointer gestures'
-      },
-      {
-        href: '/accessibility/notifications',
-        text: 'Notifications'
-      },
-      {
-        href: '/accessibility/forms/keyboard',
-        text: '- Keyboard'
-      },
-      {
-        href: '/accessibility/timeouts',
-        text: 'Timeouts'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Written content</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/inclusive-language',
-          text: 'Inclusive language'
-        },
-        {
-          href: '/accessibility/readability',
-          text: 'Readability'
-        }
-      ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Providing alternatives</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/audio-and-video',
-          text: 'Audio and video'
-        },
-        {
-          href: '/accessibility/colour-and-contrast',
-          text: 'Colour and contrast'
-        },
-        {
-          href: '/accessibility/images',
-          text: 'Images'
-        },
-        {
-          href: '/accessibility/moving-and-flashing-content',
-          text: 'Moving and flashing content'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/standard',
-            text: 'Accessibility Standard'
-          },
-          {
-            href: '/accessibility/standard/perceivable',
-            text: '- Perceivable'
-          },
-          {
-            href: '/accessibility/standard/operable',
-            text: '- Operable'
-          },
-          {
-            href: '/accessibility/standard/understandable',
-            text: '- Understandable'
-          },
-          {
-            href: '/accessibility/standard/robust',
-            text: '- Robust'
-          },
-          {
-            href: '/accessibility/standard/meet-user-needs',
-            text: '- Meet user needs'
-          },
-          {
-            href: '/accessibility/resources',
-            text: 'Guidance, tools and further reading'
-          }
-        ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>

--- a/apps/docs/src/common/pages/accessibility/inclusive-language.tsx
+++ b/apps/docs/src/common/pages/accessibility/inclusive-language.tsx
@@ -1,8 +1,8 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
-
+import { A } from '@not-govuk/components';
+import { menu } from '../accessibility'
 
 export const title = 'Inclusive language';
 const description = 'How to use inclusive language on digital services';
@@ -18,137 +18,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/headings',
-        text: 'Headings'
-      },
-      {
-        href: '/accessibility/layout-typography',
-        text: 'Layout and typography'
-      },
-      {
-        href: '/accessibility/links',
-        text: 'Links'
-      },
-      {
-        href: '/accessibility/navigation',
-        text: 'Navigation'
-      },
-      {
-        href: '/accessibility/tables',
-        text: 'Tables'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Interactivity</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/error-messages',
-        text: 'Error messages'
-      },
-      {
-        href: '/accessibility/forms',
-        text: 'Forms'
-      },
-      {
-        href: '/accessibility/keyboard',
-        text: 'Keyboard basics'
-      },
-      {
-        href: '/accessibility/keyboard/tab-navigation',
-        text: '- Tab navigation'
-      },
-      {
-        href: '/accessibility/keyboard/focus',
-        text: '- Focus'
-      },
-      {
-        href: '/accessibility/keyboard/skip-to-content',
-        text: '- Skip to content links'
-      },
-      {
-        href: '/accessibility/keyboard/character-key-shortcuts',
-        text: '- Character key shortcuts'
-      },
-      {
-        href: '/accessibility/keyboard/pointer-gestures',
-        text: '- Pointer gestures'
-      },
-      {
-        href: '/accessibility/notifications',
-        text: 'Notifications'
-      },
-      {
-        href: '/accessibility/forms/keyboard',
-        text: '- Keyboard'
-      },
-      {
-        href: '/accessibility/timeouts',
-        text: 'Timeouts'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Written content</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/inclusive-language',
-          text: 'Inclusive language'
-        },
-        {
-          href: '/accessibility/readability',
-          text: 'Readability'
-        }
-      ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Providing alternatives</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/audio-and-video',
-          text: 'Audio and video'
-        },
-        {
-          href: '/accessibility/colour-and-contrast',
-          text: 'Colour and contrast'
-        },
-        {
-          href: '/accessibility/images',
-          text: 'Images'
-        },
-        {
-          href: '/accessibility/moving-and-flashing-content',
-          text: 'Moving and flashing content'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/standard',
-            text: 'Accessibility Standard'
-          },
-          {
-            href: '/accessibility/standard/perceivable',
-            text: '- Perceivable'
-          },
-          {
-            href: '/accessibility/standard/operable',
-            text: '- Operable'
-          },
-          {
-            href: '/accessibility/standard/understandable',
-            text: '- Understandable'
-          },
-          {
-            href: '/accessibility/standard/robust',
-            text: '- Robust'
-          },
-          {
-            href: '/accessibility/standard/meet-user-needs',
-            text: '- Meet user needs'
-          },
-          {
-            href: '/accessibility/resources',
-            text: 'Guidance, tools and further reading'
-          }
-        ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>

--- a/apps/docs/src/common/pages/accessibility/keyboard.tsx
+++ b/apps/docs/src/common/pages/accessibility/keyboard.tsx
@@ -1,7 +1,8 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../accessibility'
 
 export const title = 'Keyboard';
 const description = 'Accessibility guidance for keyboard content';
@@ -17,137 +18,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/headings',
-        text: 'Headings'
-      },
-      {
-        href: '/accessibility/layout-typography',
-        text: 'Layout and typography'
-      },
-      {
-        href: '/accessibility/links',
-        text: 'Links'
-      },
-      {
-        href: '/accessibility/navigation',
-        text: 'Navigation'
-      },
-      {
-        href: '/accessibility/tables',
-        text: 'Tables'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Interactivity</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/error-messages',
-        text: 'Error messages'
-      },
-      {
-        href: '/accessibility/forms',
-        text: 'Forms'
-      },
-      {
-        href: '/accessibility/keyboard',
-        text: 'Keyboard basics'
-      },
-      {
-        href: '/accessibility/keyboard/tab-navigation',
-        text: '- Tab navigation'
-      },
-      {
-        href: '/accessibility/keyboard/focus',
-        text: '- Focus'
-      },
-      {
-        href: '/accessibility/keyboard/skip-to-content',
-        text: '- Skip to content links'
-      },
-      {
-        href: '/accessibility/keyboard/character-key-shortcuts',
-        text: '- Character key shortcuts'
-      },
-      {
-        href: '/accessibility/keyboard/pointer-gestures',
-        text: '- Pointer gestures'
-      },
-      {
-        href: '/accessibility/notifications',
-        text: 'Notifications'
-      },
-      {
-        href: '/accessibility/forms/keyboard',
-        text: '- Keyboard'
-      },
-      {
-        href: '/accessibility/timeouts',
-        text: 'Timeouts'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Written content</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/inclusive-language',
-          text: 'Inclusive language'
-        },
-        {
-          href: '/accessibility/readability',
-          text: 'Readability'
-        }
-      ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Providing alternatives</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/audio-and-video',
-          text: 'Audio and video'
-        },
-        {
-          href: '/accessibility/colour-and-contrast',
-          text: 'Colour and contrast'
-        },
-        {
-          href: '/accessibility/images',
-          text: 'Images'
-        },
-        {
-          href: '/accessibility/moving-and-flashing-content',
-          text: 'Moving and flashing content'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/standard',
-            text: 'Accessibility Standard'
-          },
-          {
-            href: '/accessibility/standard/perceivable',
-            text: '- Perceivable'
-          },
-          {
-            href: '/accessibility/standard/operable',
-            text: '- Operable'
-          },
-          {
-            href: '/accessibility/standard/understandable',
-            text: '- Understandable'
-          },
-          {
-            href: '/accessibility/standard/robust',
-            text: '- Robust'
-          },
-          {
-            href: '/accessibility/standard/meet-user-needs',
-            text: '- Meet user needs'
-          },
-          {
-            href: '/accessibility/resources',
-            text: 'Guidance, tools and further reading'
-          }
-        ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>

--- a/apps/docs/src/common/pages/accessibility/keyboard/character-key-shortcuts.tsx
+++ b/apps/docs/src/common/pages/accessibility/keyboard/character-key-shortcuts.tsx
@@ -1,14 +1,15 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
-
-const tabImage01 = require('../../../../../assets/images/accessibility/tab-01.png').default;
-const tabImage02 = require('../../../../../assets/images/accessibility/tab-02.png').default;
+import { A } from '@not-govuk/components';
+import { menu } from '../../accessibility'
 
 export const title = 'Character key shortcuts';
 const description = 'Accessibility guidance for keyboard content';
 export const section = 'Accessibility';
+
+const tabImage01 = require('../../../../../assets/images/accessibility/tab-01.png').default;
+const tabImage02 = require('../../../../../assets/images/accessibility/tab-02.png').default;
 
 const Page: FC<PageProps> = ({ location }) => (
   <div className="govuk-grid-row">
@@ -20,137 +21,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/headings',
-        text: 'Headings'
-      },
-      {
-        href: '/accessibility/layout-typography',
-        text: 'Layout and typography'
-      },
-      {
-        href: '/accessibility/links',
-        text: 'Links'
-      },
-      {
-        href: '/accessibility/navigation',
-        text: 'Navigation'
-      },
-      {
-        href: '/accessibility/tables',
-        text: 'Tables'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Interactivity</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/error-messages',
-        text: 'Error messages'
-      },
-      {
-        href: '/accessibility/forms',
-        text: 'Forms'
-      },
-      {
-        href: '/accessibility/keyboard',
-        text: 'Keyboard basics'
-      },
-      {
-        href: '/accessibility/keyboard/tab-navigation',
-        text: '- Tab navigation'
-      },
-      {
-        href: '/accessibility/keyboard/focus',
-        text: '- Focus'
-      },
-      {
-        href: '/accessibility/keyboard/skip-to-content',
-        text: '- Skip to content links'
-      },
-      {
-        href: '/accessibility/keyboard/character-key-shortcuts',
-        text: '- Character key shortcuts'
-      },
-      {
-        href: '/accessibility/keyboard/pointer-gestures',
-        text: '- Pointer gestures'
-      },
-      {
-        href: '/accessibility/notifications',
-        text: 'Notifications'
-      },
-      {
-        href: '/accessibility/forms/keyboard',
-        text: '- Keyboard'
-      },
-      {
-        href: '/accessibility/timeouts',
-        text: 'Timeouts'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Written content</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/inclusive-language',
-          text: 'Inclusive language'
-        },
-        {
-          href: '/accessibility/readability',
-          text: 'Readability'
-        }
-      ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Providing alternatives</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/audio-and-video',
-          text: 'Audio and video'
-        },
-        {
-          href: '/accessibility/colour-and-contrast',
-          text: 'Colour and contrast'
-        },
-        {
-          href: '/accessibility/images',
-          text: 'Images'
-        },
-        {
-          href: '/accessibility/moving-and-flashing-content',
-          text: 'Moving and flashing content'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/standard',
-            text: 'Accessibility Standard'
-          },
-          {
-            href: '/accessibility/standard/perceivable',
-            text: '- Perceivable'
-          },
-          {
-            href: '/accessibility/standard/operable',
-            text: '- Operable'
-          },
-          {
-            href: '/accessibility/standard/understandable',
-            text: '- Understandable'
-          },
-          {
-            href: '/accessibility/standard/robust',
-            text: '- Robust'
-          },
-          {
-            href: '/accessibility/standard/meet-user-needs',
-            text: '- Meet user needs'
-          },
-          {
-            href: '/accessibility/resources',
-            text: 'Guidance, tools and further reading'
-          }
-        ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>

--- a/apps/docs/src/common/pages/accessibility/keyboard/focus.tsx
+++ b/apps/docs/src/common/pages/accessibility/keyboard/focus.tsx
@@ -1,17 +1,18 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../../accessibility'
+
+export const title = 'Focus';
+const description = 'Accessibility guidance for keyboard content';
+export const section = 'Accessibility';
 
 const focusImage01 = require('../../../../../assets/images/accessibility/focus-01.png').default;
 const focusImage02 = require('../../../../../assets/images/accessibility/focus-02.png').default;
 const focusImage03 = require('../../../../../assets/images/accessibility/focus-03.png').default;
 const focusImage04 = require('../../../../../assets/images/accessibility/focus-04.png').default;
 const focusImage05 = require('../../../../../assets/images/accessibility/focus-05.png').default;
-
-export const title = 'Focus';
-const description = 'Accessibility guidance for keyboard content';
-export const section = 'Accessibility';
 
 const Page: FC<PageProps> = ({ location }) => (
   <div className="govuk-grid-row">
@@ -23,137 +24,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/headings',
-        text: 'Headings'
-      },
-      {
-        href: '/accessibility/layout-typography',
-        text: 'Layout and typography'
-      },
-      {
-        href: '/accessibility/links',
-        text: 'Links'
-      },
-      {
-        href: '/accessibility/navigation',
-        text: 'Navigation'
-      },
-      {
-        href: '/accessibility/tables',
-        text: 'Tables'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Interactivity</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/error-messages',
-        text: 'Error messages'
-      },
-      {
-        href: '/accessibility/forms',
-        text: 'Forms'
-      },
-      {
-        href: '/accessibility/keyboard',
-        text: 'Keyboard basics'
-      },
-      {
-        href: '/accessibility/keyboard/tab-navigation',
-        text: '- Tab navigation'
-      },
-      {
-        href: '/accessibility/keyboard/focus',
-        text: '- Focus'
-      },
-      {
-        href: '/accessibility/keyboard/skip-to-content',
-        text: '- Skip to content links'
-      },
-      {
-        href: '/accessibility/keyboard/character-key-shortcuts',
-        text: '- Character key shortcuts'
-      },
-      {
-        href: '/accessibility/keyboard/pointer-gestures',
-        text: '- Pointer gestures'
-      },
-      {
-        href: '/accessibility/notifications',
-        text: 'Notifications'
-      },
-      {
-        href: '/accessibility/forms/keyboard',
-        text: '- Keyboard'
-      },
-      {
-        href: '/accessibility/timeouts',
-        text: 'Timeouts'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Written content</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/inclusive-language',
-          text: 'Inclusive language'
-        },
-        {
-          href: '/accessibility/readability',
-          text: 'Readability'
-        }
-      ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Providing alternatives</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/audio-and-video',
-          text: 'Audio and video'
-        },
-        {
-          href: '/accessibility/colour-and-contrast',
-          text: 'Colour and contrast'
-        },
-        {
-          href: '/accessibility/images',
-          text: 'Images'
-        },
-        {
-          href: '/accessibility/moving-and-flashing-content',
-          text: 'Moving and flashing content'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/standard',
-            text: 'Accessibility Standard'
-          },
-          {
-            href: '/accessibility/standard/perceivable',
-            text: '- Perceivable'
-          },
-          {
-            href: '/accessibility/standard/operable',
-            text: '- Operable'
-          },
-          {
-            href: '/accessibility/standard/understandable',
-            text: '- Understandable'
-          },
-          {
-            href: '/accessibility/standard/robust',
-            text: '- Robust'
-          },
-          {
-            href: '/accessibility/standard/meet-user-needs',
-            text: '- Meet user needs'
-          },
-          {
-            href: '/accessibility/resources',
-            text: 'Guidance, tools and further reading'
-          }
-        ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>

--- a/apps/docs/src/common/pages/accessibility/keyboard/pointer-gestures.tsx
+++ b/apps/docs/src/common/pages/accessibility/keyboard/pointer-gestures.tsx
@@ -1,7 +1,8 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../../accessibility'
 
 export const title = 'Pointer gestures';
 const description = 'Accessibility guidance for keyboard content';
@@ -17,137 +18,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/headings',
-        text: 'Headings'
-      },
-      {
-        href: '/accessibility/layout-typography',
-        text: 'Layout and typography'
-      },
-      {
-        href: '/accessibility/links',
-        text: 'Links'
-      },
-      {
-        href: '/accessibility/navigation',
-        text: 'Navigation'
-      },
-      {
-        href: '/accessibility/tables',
-        text: 'Tables'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Interactivity</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/error-messages',
-        text: 'Error messages'
-      },
-      {
-        href: '/accessibility/forms',
-        text: 'Forms'
-      },
-      {
-        href: '/accessibility/keyboard',
-        text: 'Keyboard basics'
-      },
-      {
-        href: '/accessibility/keyboard/tab-navigation',
-        text: '- Tab navigation'
-      },
-      {
-        href: '/accessibility/keyboard/focus',
-        text: '- Focus'
-      },
-      {
-        href: '/accessibility/keyboard/skip-to-content',
-        text: '- Skip to content links'
-      },
-      {
-        href: '/accessibility/keyboard/character-key-shortcuts',
-        text: '- Character key shortcuts'
-      },
-      {
-        href: '/accessibility/keyboard/pointer-gestures',
-        text: '- Pointer gestures'
-      },
-      {
-        href: '/accessibility/notifications',
-        text: 'Notifications'
-      },
-      {
-        href: '/accessibility/forms/keyboard',
-        text: '- Keyboard'
-      },
-      {
-        href: '/accessibility/timeouts',
-        text: 'Timeouts'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Written content</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/inclusive-language',
-          text: 'Inclusive language'
-        },
-        {
-          href: '/accessibility/readability',
-          text: 'Readability'
-        }
-      ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Providing alternatives</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/audio-and-video',
-          text: 'Audio and video'
-        },
-        {
-          href: '/accessibility/colour-and-contrast',
-          text: 'Colour and contrast'
-        },
-        {
-          href: '/accessibility/images',
-          text: 'Images'
-        },
-        {
-          href: '/accessibility/moving-and-flashing-content',
-          text: 'Moving and flashing content'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/standard',
-            text: 'Accessibility Standard'
-          },
-          {
-            href: '/accessibility/standard/perceivable',
-            text: '- Perceivable'
-          },
-          {
-            href: '/accessibility/standard/operable',
-            text: '- Operable'
-          },
-          {
-            href: '/accessibility/standard/understandable',
-            text: '- Understandable'
-          },
-          {
-            href: '/accessibility/standard/robust',
-            text: '- Robust'
-          },
-          {
-            href: '/accessibility/standard/meet-user-needs',
-            text: '- Meet user needs'
-          },
-          {
-            href: '/accessibility/resources',
-            text: 'Guidance, tools and further reading'
-          }
-        ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>

--- a/apps/docs/src/common/pages/accessibility/keyboard/skip-to-content.tsx
+++ b/apps/docs/src/common/pages/accessibility/keyboard/skip-to-content.tsx
@@ -1,13 +1,14 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
-
-const skipImage01 = require('../../../../../assets/images/accessibility/skip-01.png').default;
+import { A } from '@not-govuk/components';
+import { menu } from '../../accessibility'
 
 export const title = 'Skip to content links';
 const description = 'Accessibility guidance for keyboard content';
 export const section = 'Accessibility';
+
+const skipImage01 = require('../../../../../assets/images/accessibility/skip-01.png').default;
 
 const Page: FC<PageProps> = ({ location }) => (
   <div className="govuk-grid-row">
@@ -19,137 +20,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/headings',
-        text: 'Headings'
-      },
-      {
-        href: '/accessibility/layout-typography',
-        text: 'Layout and typography'
-      },
-      {
-        href: '/accessibility/links',
-        text: 'Links'
-      },
-      {
-        href: '/accessibility/navigation',
-        text: 'Navigation'
-      },
-      {
-        href: '/accessibility/tables',
-        text: 'Tables'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Interactivity</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/error-messages',
-        text: 'Error messages'
-      },
-      {
-        href: '/accessibility/forms',
-        text: 'Forms'
-      },
-      {
-        href: '/accessibility/keyboard',
-        text: 'Keyboard basics'
-      },
-      {
-        href: '/accessibility/keyboard/tab-navigation',
-        text: '- Tab navigation'
-      },
-      {
-        href: '/accessibility/keyboard/focus',
-        text: '- Focus'
-      },
-      {
-        href: '/accessibility/keyboard/skip-to-content',
-        text: '- Skip to content links'
-      },
-      {
-        href: '/accessibility/keyboard/character-key-shortcuts',
-        text: '- Character key shortcuts'
-      },
-      {
-        href: '/accessibility/keyboard/pointer-gestures',
-        text: '- Pointer gestures'
-      },
-      {
-        href: '/accessibility/notifications',
-        text: 'Notifications'
-      },
-      {
-        href: '/accessibility/forms/keyboard',
-        text: '- Keyboard'
-      },
-      {
-        href: '/accessibility/timeouts',
-        text: 'Timeouts'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Written content</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/inclusive-language',
-          text: 'Inclusive language'
-        },
-        {
-          href: '/accessibility/readability',
-          text: 'Readability'
-        }
-      ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Providing alternatives</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/audio-and-video',
-          text: 'Audio and video'
-        },
-        {
-          href: '/accessibility/colour-and-contrast',
-          text: 'Colour and contrast'
-        },
-        {
-          href: '/accessibility/images',
-          text: 'Images'
-        },
-        {
-          href: '/accessibility/moving-and-flashing-content',
-          text: 'Moving and flashing content'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/standard',
-            text: 'Accessibility Standard'
-          },
-          {
-            href: '/accessibility/standard/perceivable',
-            text: '- Perceivable'
-          },
-          {
-            href: '/accessibility/standard/operable',
-            text: '- Operable'
-          },
-          {
-            href: '/accessibility/standard/understandable',
-            text: '- Understandable'
-          },
-          {
-            href: '/accessibility/standard/robust',
-            text: '- Robust'
-          },
-          {
-            href: '/accessibility/standard/meet-user-needs',
-            text: '- Meet user needs'
-          },
-          {
-            href: '/accessibility/resources',
-            text: 'Guidance, tools and further reading'
-          }
-        ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>

--- a/apps/docs/src/common/pages/accessibility/keyboard/tab-navigation.tsx
+++ b/apps/docs/src/common/pages/accessibility/keyboard/tab-navigation.tsx
@@ -1,14 +1,15 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
-
-const tabImage01 = require('../../../../../assets/images/accessibility/tab-01.png').default;
-const tabImage02 = require('../../../../../assets/images/accessibility/tab-02.png').default;
+import { A } from '@not-govuk/components';
+import { menu } from '../../accessibility'
 
 export const title = 'Tab navigation';
 const description = 'Accessibility guidance for keyboard content';
 export const section = 'Accessibility';
+
+const tabImage01 = require('../../../../../assets/images/accessibility/tab-01.png').default;
+const tabImage02 = require('../../../../../assets/images/accessibility/tab-02.png').default;
 
 const Page: FC<PageProps> = ({ location }) => (
   <div className="govuk-grid-row">
@@ -20,137 +21,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/headings',
-        text: 'Headings'
-      },
-      {
-        href: '/accessibility/layout-typography',
-        text: 'Layout and typography'
-      },
-      {
-        href: '/accessibility/links',
-        text: 'Links'
-      },
-      {
-        href: '/accessibility/navigation',
-        text: 'Navigation'
-      },
-      {
-        href: '/accessibility/tables',
-        text: 'Tables'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Interactivity</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/error-messages',
-        text: 'Error messages'
-      },
-      {
-        href: '/accessibility/forms',
-        text: 'Forms'
-      },
-      {
-        href: '/accessibility/keyboard',
-        text: 'Keyboard basics'
-      },
-      {
-        href: '/accessibility/keyboard/tab-navigation',
-        text: '- Tab navigation'
-      },
-      {
-        href: '/accessibility/keyboard/focus',
-        text: '- Focus'
-      },
-      {
-        href: '/accessibility/keyboard/skip-to-content',
-        text: '- Skip to content links'
-      },
-      {
-        href: '/accessibility/keyboard/character-key-shortcuts',
-        text: '- Character key shortcuts'
-      },
-      {
-        href: '/accessibility/keyboard/pointer-gestures',
-        text: '- Pointer gestures'
-      },
-      {
-        href: '/accessibility/notifications',
-        text: 'Notifications'
-      },
-      {
-        href: '/accessibility/forms/keyboard',
-        text: '- Keyboard'
-      },
-      {
-        href: '/accessibility/timeouts',
-        text: 'Timeouts'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Written content</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/inclusive-language',
-          text: 'Inclusive language'
-        },
-        {
-          href: '/accessibility/readability',
-          text: 'Readability'
-        }
-      ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Providing alternatives</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/audio-and-video',
-          text: 'Audio and video'
-        },
-        {
-          href: '/accessibility/colour-and-contrast',
-          text: 'Colour and contrast'
-        },
-        {
-          href: '/accessibility/images',
-          text: 'Images'
-        },
-        {
-          href: '/accessibility/moving-and-flashing-content',
-          text: 'Moving and flashing content'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/standard',
-            text: 'Accessibility Standard'
-          },
-          {
-            href: '/accessibility/standard/perceivable',
-            text: '- Perceivable'
-          },
-          {
-            href: '/accessibility/standard/operable',
-            text: '- Operable'
-          },
-          {
-            href: '/accessibility/standard/understandable',
-            text: '- Understandable'
-          },
-          {
-            href: '/accessibility/standard/robust',
-            text: '- Robust'
-          },
-          {
-            href: '/accessibility/standard/meet-user-needs',
-            text: '- Meet user needs'
-          },
-          {
-            href: '/accessibility/resources',
-            text: 'Guidance, tools and further reading'
-          }
-        ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>

--- a/apps/docs/src/common/pages/accessibility/layout-typography.tsx
+++ b/apps/docs/src/common/pages/accessibility/layout-typography.tsx
@@ -1,7 +1,8 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../accessibility'
 
 const layoutImage01 = require('../../../../assets/images/accessibility/landmarks1.png').default;
 const layoutImage02 = require('../../../../assets/images/accessibility/landmarks2.png').default;
@@ -20,97 +21,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/links',
-          text: 'Links'
-        },
-        {
-          href: '/accessibility/navigation',
-          text: 'Navigation'
-        },
-        {
-          href: '/accessibility/tables',
-          text: 'Tables'
-        },
-        {
-          href: '/accessibility/headings',
-          text: 'Headings'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Interactivity</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/error-messages',
-          text: 'Error messages'
-        },
-        {
-          href: '/accessibility/keyboard',
-          text: 'Keyboard basics'
-        },
-        {
-          href: '/accessibility/keyboard/tab-navigation',
-          text: '- Tab navigation'
-        },
-        {
-          href: '/accessibility/keyboard/focus',
-          text: '- Focus'
-        },
-        {
-          href: '/accessibility/keyboard/skip-to-content',
-          text: '- Skip to content links'
-        },
-        {
-          href: '/accessibility/keyboard/character-key-shortcuts',
-          text: '- Character key shortcuts'
-        },
-        {
-          href: '/accessibility/keyboard/pointer-gestures',
-          text: '- Pointer gestures'
-        },
-        {
-          href: '/accessibility/forms',
-          text: 'Forms'
-        },
-        {
-          href: '/accessibility/timeouts',
-          text: 'Timeouts'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Written content</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/inclusive-language',
-            text: 'Inclusive language'
-          },
-          {
-            href: '/accessibility/readability',
-            text: 'Readability'
-          },
-        ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Providing alternatives</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/audio-and-video',
-            text: 'Audio and video'
-          },
-          {
-            href: '/accessibility/colour-and-contrast',
-            text: 'Colour and contrast'
-          },
-          {
-            href: '/accessibility/images',
-            text: 'Images'
-          }
-        ]} />
-        <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Resources</span>
-          <NavigationMenu items={[
-            {
-              href: '/accessibility/resources',
-              text: 'Guidance, tools and further reading'
-            }
-          ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>

--- a/apps/docs/src/common/pages/accessibility/links.tsx
+++ b/apps/docs/src/common/pages/accessibility/links.tsx
@@ -1,7 +1,8 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../accessibility'
 
 const linksImage02 = require('../../../../assets/images/accessibility/links02.png').default;
 const linksImage03 = require('../../../../assets/images/accessibility/links03.png').default;
@@ -22,137 +23,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/headings',
-        text: 'Headings'
-      },
-      {
-        href: '/accessibility/layout-typography',
-        text: 'Layout and typography'
-      },
-      {
-        href: '/accessibility/links',
-        text: 'Links'
-      },
-      {
-        href: '/accessibility/navigation',
-        text: 'Navigation'
-      },
-      {
-        href: '/accessibility/tables',
-        text: 'Tables'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Interactivity</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/error-messages',
-        text: 'Error messages'
-      },
-      {
-        href: '/accessibility/forms',
-        text: 'Forms'
-      },
-      {
-        href: '/accessibility/keyboard',
-        text: 'Keyboard basics'
-      },
-      {
-        href: '/accessibility/keyboard/tab-navigation',
-        text: '- Tab navigation'
-      },
-      {
-        href: '/accessibility/keyboard/focus',
-        text: '- Focus'
-      },
-      {
-        href: '/accessibility/keyboard/skip-to-content',
-        text: '- Skip to content links'
-      },
-      {
-        href: '/accessibility/keyboard/character-key-shortcuts',
-        text: '- Character key shortcuts'
-      },
-      {
-        href: '/accessibility/keyboard/pointer-gestures',
-        text: '- Pointer gestures'
-      },
-      {
-        href: '/accessibility/notifications',
-        text: 'Notifications'
-      },
-      {
-        href: '/accessibility/forms/keyboard',
-        text: '- Keyboard'
-      },
-      {
-        href: '/accessibility/timeouts',
-        text: 'Timeouts'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Written content</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/inclusive-language',
-          text: 'Inclusive language'
-        },
-        {
-          href: '/accessibility/readability',
-          text: 'Readability'
-        }
-      ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Providing alternatives</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/audio-and-video',
-          text: 'Audio and video'
-        },
-        {
-          href: '/accessibility/colour-and-contrast',
-          text: 'Colour and contrast'
-        },
-        {
-          href: '/accessibility/images',
-          text: 'Images'
-        },
-        {
-          href: '/accessibility/moving-and-flashing-content',
-          text: 'Moving and flashing content'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/standard',
-            text: 'Accessibility Standard'
-          },
-          {
-            href: '/accessibility/standard/perceivable',
-            text: '- Perceivable'
-          },
-          {
-            href: '/accessibility/standard/operable',
-            text: '- Operable'
-          },
-          {
-            href: '/accessibility/standard/understandable',
-            text: '- Understandable'
-          },
-          {
-            href: '/accessibility/standard/robust',
-            text: '- Robust'
-          },
-          {
-            href: '/accessibility/standard/meet-user-needs',
-            text: '- Meet user needs'
-          },
-          {
-            href: '/accessibility/resources',
-            text: 'Guidance, tools and further reading'
-          }
-        ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>

--- a/apps/docs/src/common/pages/accessibility/moving-and-flashing-content.tsx
+++ b/apps/docs/src/common/pages/accessibility/moving-and-flashing-content.tsx
@@ -1,7 +1,8 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../accessibility'
 
 const movingImage01 = require('../../../../assets/images/accessibility/moving-and-flashing-01.png').default;
 
@@ -19,133 +20,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/headings',
-        text: 'Headings'
-      },
-      {
-        href: '/accessibility/links',
-        text: 'Links'
-      },
-      {
-        href: '/accessibility/navigation',
-        text: 'Navigation'
-      },
-      {
-        href: '/accessibility/tables',
-        text: 'Tables'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Interactivity</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/error-messages',
-        text: 'Error messages'
-      },
-      {
-        href: '/accessibility/forms',
-        text: 'Forms'
-      },
-      {
-        href: '/accessibility/keyboard',
-        text: 'Keyboard basics'
-      },
-      {
-        href: '/accessibility/keyboard/tab-navigation',
-        text: '- Tab navigation'
-      },
-      {
-        href: '/accessibility/keyboard/focus',
-        text: '- Focus'
-      },
-      {
-        href: '/accessibility/keyboard/skip-to-content',
-        text: '- Skip to content links'
-      },
-      {
-        href: '/accessibility/keyboard/character-key-shortcuts',
-        text: '- Character key shortcuts'
-      },
-      {
-        href: '/accessibility/keyboard/pointer-gestures',
-        text: '- Pointer gestures'
-      },
-      {
-        href: '/accessibility/notifications',
-        text: 'Notifications'
-      },
-      {
-        href: '/accessibility/forms/keyboard',
-        text: '- Keyboard'
-      },
-      {
-        href: '/accessibility/timeouts',
-        text: 'Timeouts'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Written content</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/inclusive-language',
-          text: 'Inclusive language'
-        },
-        {
-          href: '/accessibility/readability',
-          text: 'Readability'
-        },
-      ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Providing alternatives</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/audio-and-video',
-          text: 'Audio and video'
-        },
-        {
-          href: '/accessibility/colour-and-contrast',
-          text: 'Colour and contrast'
-        },
-        {
-          href: '/accessibility/images',
-          text: 'Images'
-        },
-        {
-          href: '/accessibility/moving-and-flashing-content',
-          text: 'Moving and flashing content'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/standard',
-            text: 'Accessibility Standard'
-          },
-          {
-            href: '/accessibility/standard/perceivable',
-            text: '- Perceivable'
-          },
-          {
-            href: '/accessibility/standard/operable',
-            text: '- Operable'
-          },
-          {
-            href: '/accessibility/standard/understandable',
-            text: '- Understandable'
-          },
-          {
-            href: '/accessibility/standard/robust',
-            text: '- Robust'
-          },
-          {
-            href: '/accessibility/standard/meet-user-needs',
-            text: '- Meet user needs'
-          },
-          {
-            href: '/accessibility/resources',
-            text: 'Guidance, tools and further reading'
-          }
-        ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
 

--- a/apps/docs/src/common/pages/accessibility/navigation.tsx
+++ b/apps/docs/src/common/pages/accessibility/navigation.tsx
@@ -1,7 +1,8 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../accessibility'
 
 const navigationImage01 = require('../../../../assets/images/accessibility/navigation-01.png').default;
 const navigationImage03 = require('../../../../assets/images/accessibility/navigation-03.png').default;
@@ -20,137 +21,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/headings',
-        text: 'Headings'
-      },
-      {
-        href: '/accessibility/layout-typography',
-        text: 'Layout and typography'
-      },
-      {
-        href: '/accessibility/links',
-        text: 'Links'
-      },
-      {
-        href: '/accessibility/navigation',
-        text: 'Navigation'
-      },
-      {
-        href: '/accessibility/tables',
-        text: 'Tables'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Interactivity</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/error-messages',
-        text: 'Error messages'
-      },
-      {
-        href: '/accessibility/forms',
-        text: 'Forms'
-      },
-      {
-        href: '/accessibility/keyboard',
-        text: 'Keyboard basics'
-      },
-      {
-        href: '/accessibility/keyboard/tab-navigation',
-        text: '- Tab navigation'
-      },
-      {
-        href: '/accessibility/keyboard/focus',
-        text: '- Focus'
-      },
-      {
-        href: '/accessibility/keyboard/skip-to-content',
-        text: '- Skip to content links'
-      },
-      {
-        href: '/accessibility/keyboard/character-key-shortcuts',
-        text: '- Character key shortcuts'
-      },
-      {
-        href: '/accessibility/keyboard/pointer-gestures',
-        text: '- Pointer gestures'
-      },
-      {
-        href: '/accessibility/notifications',
-        text: 'Notifications'
-      },
-      {
-        href: '/accessibility/forms/keyboard',
-        text: '- Keyboard'
-      },
-      {
-        href: '/accessibility/timeouts',
-        text: 'Timeouts'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Written content</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/inclusive-language',
-          text: 'Inclusive language'
-        },
-        {
-          href: '/accessibility/readability',
-          text: 'Readability'
-        }
-      ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Providing alternatives</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/audio-and-video',
-          text: 'Audio and video'
-        },
-        {
-          href: '/accessibility/colour-and-contrast',
-          text: 'Colour and contrast'
-        },
-        {
-          href: '/accessibility/images',
-          text: 'Images'
-        },
-        {
-          href: '/accessibility/moving-and-flashing-content',
-          text: 'Moving and flashing content'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/standard',
-            text: 'Accessibility Standard'
-          },
-          {
-            href: '/accessibility/standard/perceivable',
-            text: '- Perceivable'
-          },
-          {
-            href: '/accessibility/standard/operable',
-            text: '- Operable'
-          },
-          {
-            href: '/accessibility/standard/understandable',
-            text: '- Understandable'
-          },
-          {
-            href: '/accessibility/standard/robust',
-            text: '- Robust'
-          },
-          {
-            href: '/accessibility/standard/meet-user-needs',
-            text: '- Meet user needs'
-          },
-          {
-            href: '/accessibility/resources',
-            text: 'Guidance, tools and further reading'
-          }
-        ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>

--- a/apps/docs/src/common/pages/accessibility/notifications.tsx
+++ b/apps/docs/src/common/pages/accessibility/notifications.tsx
@@ -1,7 +1,8 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../accessibility'
 
 const notificationsImage = require('../../../../assets/images/accessibility/notifications.png').default;
 
@@ -19,133 +20,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/headings',
-        text: 'Headings'
-      },
-      {
-        href: '/accessibility/links',
-        text: 'Links'
-      },
-      {
-        href: '/accessibility/navigation',
-        text: 'Navigation'
-      },
-      {
-        href: '/accessibility/tables',
-        text: 'Tables'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Interactivity</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/error-messages',
-        text: 'Error messages'
-      },
-      {
-        href: '/accessibility/forms',
-        text: 'Forms'
-      },
-      {
-        href: '/accessibility/keyboard',
-        text: 'Keyboard basics'
-      },
-      {
-        href: '/accessibility/keyboard/tab-navigation',
-        text: '- Tab navigation'
-      },
-      {
-        href: '/accessibility/keyboard/focus',
-        text: '- Focus'
-      },
-      {
-        href: '/accessibility/keyboard/skip-to-content',
-        text: '- Skip to content links'
-      },
-      {
-        href: '/accessibility/keyboard/character-key-shortcuts',
-        text: '- Character key shortcuts'
-      },
-      {
-        href: '/accessibility/keyboard/pointer-gestures',
-        text: '- Pointer gestures'
-      },
-      {
-        href: '/accessibility/notifications',
-        text: 'Notifications'
-      },
-      {
-        href: '/accessibility/forms/keyboard',
-        text: '- Keyboard'
-      },
-      {
-        href: '/accessibility/timeouts',
-        text: 'Timeouts'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Written content</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/inclusive-language',
-          text: 'Inclusive language'
-        },
-        {
-          href: '/accessibility/readability',
-          text: 'Readability'
-        },
-      ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Providing alternatives</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/audio-and-video',
-          text: 'Audio and video'
-        },
-        {
-          href: '/accessibility/colour-and-contrast',
-          text: 'Colour and contrast'
-        },
-        {
-          href: '/accessibility/images',
-          text: 'Images'
-        },
-        {
-          href: '/accessibility/moving-and-flashing-content',
-          text: 'Moving and flashing content'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/standard',
-            text: 'Accessibility Standard'
-          },
-          {
-            href: '/accessibility/standard/perceivable',
-            text: '- Perceivable'
-          },
-          {
-            href: '/accessibility/standard/operable',
-            text: '- Operable'
-          },
-          {
-            href: '/accessibility/standard/understandable',
-            text: '- Understandable'
-          },
-          {
-            href: '/accessibility/standard/robust',
-            text: '- Robust'
-          },
-          {
-            href: '/accessibility/standard/meet-user-needs',
-            text: '- Meet user needs'
-          },
-          {
-            href: '/accessibility/resources',
-            text: 'Guidance, tools and further reading'
-          }
-        ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
 

--- a/apps/docs/src/common/pages/accessibility/readability.tsx
+++ b/apps/docs/src/common/pages/accessibility/readability.tsx
@@ -1,7 +1,8 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../accessibility'
 
 const linksImage01 = require('../../../../assets/images/accessibility/readability-score.png').default;
 
@@ -19,137 +20,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/headings',
-        text: 'Headings'
-      },
-      {
-        href: '/accessibility/layout-typography',
-        text: 'Layout and typography'
-      },
-      {
-        href: '/accessibility/links',
-        text: 'Links'
-      },
-      {
-        href: '/accessibility/navigation',
-        text: 'Navigation'
-      },
-      {
-        href: '/accessibility/tables',
-        text: 'Tables'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Interactivity</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/error-messages',
-        text: 'Error messages'
-      },
-      {
-        href: '/accessibility/forms',
-        text: 'Forms'
-      },
-      {
-        href: '/accessibility/keyboard',
-        text: 'Keyboard basics'
-      },
-      {
-        href: '/accessibility/keyboard/tab-navigation',
-        text: '- Tab navigation'
-      },
-      {
-        href: '/accessibility/keyboard/focus',
-        text: '- Focus'
-      },
-      {
-        href: '/accessibility/keyboard/skip-to-content',
-        text: '- Skip to content links'
-      },
-      {
-        href: '/accessibility/keyboard/character-key-shortcuts',
-        text: '- Character key shortcuts'
-      },
-      {
-        href: '/accessibility/keyboard/pointer-gestures',
-        text: '- Pointer gestures'
-      },
-      {
-        href: '/accessibility/notifications',
-        text: 'Notifications'
-      },
-      {
-        href: '/accessibility/forms/keyboard',
-        text: '- Keyboard'
-      },
-      {
-        href: '/accessibility/timeouts',
-        text: 'Timeouts'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Written content</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/inclusive-language',
-          text: 'Inclusive language'
-        },
-        {
-          href: '/accessibility/readability',
-          text: 'Readability'
-        }
-      ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Providing alternatives</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/audio-and-video',
-          text: 'Audio and video'
-        },
-        {
-          href: '/accessibility/colour-and-contrast',
-          text: 'Colour and contrast'
-        },
-        {
-          href: '/accessibility/images',
-          text: 'Images'
-        },
-        {
-          href: '/accessibility/moving-and-flashing-content',
-          text: 'Moving and flashing content'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/standard',
-            text: 'Accessibility Standard'
-          },
-          {
-            href: '/accessibility/standard/perceivable',
-            text: '- Perceivable'
-          },
-          {
-            href: '/accessibility/standard/operable',
-            text: '- Operable'
-          },
-          {
-            href: '/accessibility/standard/understandable',
-            text: '- Understandable'
-          },
-          {
-            href: '/accessibility/standard/robust',
-            text: '- Robust'
-          },
-          {
-            href: '/accessibility/standard/meet-user-needs',
-            text: '- Meet user needs'
-          },
-          {
-            href: '/accessibility/resources',
-            text: 'Guidance, tools and further reading'
-          }
-        ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>

--- a/apps/docs/src/common/pages/accessibility/resources.tsx
+++ b/apps/docs/src/common/pages/accessibility/resources.tsx
@@ -1,7 +1,8 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../accessibility'
 
 export const title = 'Resources';
 const longTitle = 'Accessibility resources';
@@ -18,137 +19,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/headings',
-        text: 'Headings'
-      },
-      {
-        href: '/accessibility/layout-typography',
-        text: 'Layout and typography'
-      },
-      {
-        href: '/accessibility/links',
-        text: 'Links'
-      },
-      {
-        href: '/accessibility/navigation',
-        text: 'Navigation'
-      },
-      {
-        href: '/accessibility/tables',
-        text: 'Tables'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Interactivity</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/error-messages',
-        text: 'Error messages'
-      },
-      {
-        href: '/accessibility/forms',
-        text: 'Forms'
-      },
-      {
-        href: '/accessibility/keyboard',
-        text: 'Keyboard basics'
-      },
-      {
-        href: '/accessibility/keyboard/tab-navigation',
-        text: '- Tab navigation'
-      },
-      {
-        href: '/accessibility/keyboard/focus',
-        text: '- Focus'
-      },
-      {
-        href: '/accessibility/keyboard/skip-to-content',
-        text: '- Skip to content links'
-      },
-      {
-        href: '/accessibility/keyboard/character-key-shortcuts',
-        text: '- Character key shortcuts'
-      },
-      {
-        href: '/accessibility/keyboard/pointer-gestures',
-        text: '- Pointer gestures'
-      },
-      {
-        href: '/accessibility/notifications',
-        text: 'Notifications'
-      },
-      {
-        href: '/accessibility/forms/keyboard',
-        text: '- Keyboard'
-      },
-      {
-        href: '/accessibility/timeouts',
-        text: 'Timeouts'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Written content</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/inclusive-language',
-          text: 'Inclusive language'
-        },
-        {
-          href: '/accessibility/readability',
-          text: 'Readability'
-        }
-      ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Providing alternatives</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/audio-and-video',
-          text: 'Audio and video'
-        },
-        {
-          href: '/accessibility/colour-and-contrast',
-          text: 'Colour and contrast'
-        },
-        {
-          href: '/accessibility/images',
-          text: 'Images'
-        },
-        {
-          href: '/accessibility/moving-and-flashing-content',
-          text: 'Moving and flashing content'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/standard',
-            text: 'Accessibility Standard'
-          },
-          {
-            href: '/accessibility/standard/perceivable',
-            text: '- Perceivable'
-          },
-          {
-            href: '/accessibility/standard/operable',
-            text: '- Operable'
-          },
-          {
-            href: '/accessibility/standard/understandable',
-            text: '- Understandable'
-          },
-          {
-            href: '/accessibility/standard/robust',
-            text: '- Robust'
-          },
-          {
-            href: '/accessibility/standard/meet-user-needs',
-            text: '- Meet user needs'
-          },
-          {
-            href: '/accessibility/resources',
-            text: 'Guidance, tools and further reading'
-          }
-        ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
     <h1>

--- a/apps/docs/src/common/pages/accessibility/standard.tsx
+++ b/apps/docs/src/common/pages/accessibility/standard.tsx
@@ -1,7 +1,8 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../accessibility'
 
 export const title = 'Accessibility Standard';
 const description = 'Accessibility Standard';
@@ -17,133 +18,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/headings',
-        text: 'Headings'
-      },
-      {
-        href: '/accessibility/links',
-        text: 'Links'
-      },
-      {
-        href: '/accessibility/navigation',
-        text: 'Navigation'
-      },
-      {
-        href: '/accessibility/tables',
-        text: 'Tables'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Interactivity</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/error-messages',
-        text: 'Error messages'
-      },
-      {
-        href: '/accessibility/forms',
-        text: 'Forms'
-      },
-      {
-        href: '/accessibility/keyboard',
-        text: 'Keyboard basics'
-      },
-      {
-        href: '/accessibility/keyboard/tab-navigation',
-        text: '- Tab navigation'
-      },
-      {
-        href: '/accessibility/keyboard/focus',
-        text: '- Focus'
-      },
-      {
-        href: '/accessibility/keyboard/skip-to-content',
-        text: '- Skip to content links'
-      },
-      {
-        href: '/accessibility/keyboard/character-key-shortcuts',
-        text: '- Character key shortcuts'
-      },
-      {
-        href: '/accessibility/keyboard/pointer-gestures',
-        text: '- Pointer gestures'
-      },
-      {
-        href: '/accessibility/notifications',
-        text: 'Notifications'
-      },
-      {
-        href: '/accessibility/forms/keyboard',
-        text: '- Keyboard'
-      },
-      {
-        href: '/accessibility/timeouts',
-        text: 'Timeouts'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Written content</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/inclusive-language',
-          text: 'Inclusive language'
-        },
-        {
-          href: '/accessibility/readability',
-          text: 'Readability'
-        },
-      ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Providing alternatives</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/audio-and-video',
-          text: 'Audio and video'
-        },
-        {
-          href: '/accessibility/colour-and-contrast',
-          text: 'Colour and contrast'
-        },
-        {
-          href: '/accessibility/images',
-          text: 'Images'
-        },
-        {
-          href: '/accessibility/moving-and-flashing-content',
-          text: 'Moving and flashing content'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/standard',
-            text: 'Accessibility Standard'
-          },
-          {
-            href: '/accessibility/standard/perceivable',
-            text: '- Perceivable'
-          },
-          {
-            href: '/accessibility/standard/operable',
-            text: '- Operable'
-          },
-          {
-            href: '/accessibility/standard/understandable',
-            text: '- Understandable'
-          },
-          {
-            href: '/accessibility/standard/robust',
-            text: '- Robust'
-          },
-          {
-            href: '/accessibility/standard/meet-user-needs',
-            text: '- Meet user needs'
-          },
-          {
-            href: '/accessibility/resources',
-            text: 'Guidance, tools and further reading'
-          }
-        ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
 

--- a/apps/docs/src/common/pages/accessibility/standard/meet-user-needs.tsx
+++ b/apps/docs/src/common/pages/accessibility/standard/meet-user-needs.tsx
@@ -1,7 +1,8 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../../accessibility'
 
 export const title = 'Meet user needs';
 const description = 'Meet user needs Accessibility Standard requirements';
@@ -17,133 +18,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/headings',
-        text: 'Headings'
-      },
-      {
-        href: '/accessibility/links',
-        text: 'Links'
-      },
-      {
-        href: '/accessibility/navigation',
-        text: 'Navigation'
-      },
-      {
-        href: '/accessibility/tables',
-        text: 'Tables'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Interactivity</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/error-messages',
-        text: 'Error messages'
-      },
-      {
-        href: '/accessibility/forms',
-        text: 'Forms'
-      },
-      {
-        href: '/accessibility/keyboard',
-        text: 'Keyboard basics'
-      },
-      {
-        href: '/accessibility/keyboard/tab-navigation',
-        text: '- Tab navigation'
-      },
-      {
-        href: '/accessibility/keyboard/focus',
-        text: '- Focus'
-      },
-      {
-        href: '/accessibility/keyboard/skip-to-content',
-        text: '- Skip to content links'
-      },
-      {
-        href: '/accessibility/keyboard/character-key-shortcuts',
-        text: '- Character key shortcuts'
-      },
-      {
-        href: '/accessibility/keyboard/pointer-gestures',
-        text: '- Pointer gestures'
-      },
-      {
-        href: '/accessibility/notifications',
-        text: 'Notifications'
-      },
-      {
-        href: '/accessibility/forms/keyboard',
-        text: '- Keyboard'
-      },
-      {
-        href: '/accessibility/timeouts',
-        text: 'Timeouts'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Written content</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/inclusive-language',
-          text: 'Inclusive language'
-        },
-        {
-          href: '/accessibility/readability',
-          text: 'Readability'
-        },
-      ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Providing alternatives</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/audio-and-video',
-          text: 'Audio and video'
-        },
-        {
-          href: '/accessibility/colour-and-contrast',
-          text: 'Colour and contrast'
-        },
-        {
-          href: '/accessibility/images',
-          text: 'Images'
-        },
-        {
-          href: '/accessibility/moving-and-flashing-content',
-          text: 'Moving and flashing content'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/standard',
-            text: 'Accessibility Standard'
-          },
-          {
-            href: '/accessibility/standard/perceivable',
-            text: '- Perceivable'
-          },
-          {
-            href: '/accessibility/standard/operable',
-            text: '- Operable'
-          },
-          {
-            href: '/accessibility/standard/understandable',
-            text: '- Understandable'
-          },
-          {
-            href: '/accessibility/standard/robust',
-            text: '- Robust'
-          },
-          {
-            href: '/accessibility/standard/meet-user-needs',
-            text: '- Meet user needs'
-          },
-          {
-            href: '/accessibility/resources',
-            text: 'Guidance, tools and further reading'
-          }
-        ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
 

--- a/apps/docs/src/common/pages/accessibility/standard/operable.tsx
+++ b/apps/docs/src/common/pages/accessibility/standard/operable.tsx
@@ -1,7 +1,8 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../../accessibility'
 
 export const title = 'Operable';
 const description = 'Operable Accessibility Standard requirements';
@@ -17,133 +18,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/headings',
-        text: 'Headings'
-      },
-      {
-        href: '/accessibility/links',
-        text: 'Links'
-      },
-      {
-        href: '/accessibility/navigation',
-        text: 'Navigation'
-      },
-      {
-        href: '/accessibility/tables',
-        text: 'Tables'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Interactivity</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/error-messages',
-        text: 'Error messages'
-      },
-      {
-        href: '/accessibility/forms',
-        text: 'Forms'
-      },
-      {
-        href: '/accessibility/keyboard',
-        text: 'Keyboard basics'
-      },
-      {
-        href: '/accessibility/keyboard/tab-navigation',
-        text: '- Tab navigation'
-      },
-      {
-        href: '/accessibility/keyboard/focus',
-        text: '- Focus'
-      },
-      {
-        href: '/accessibility/keyboard/skip-to-content',
-        text: '- Skip to content links'
-      },
-      {
-        href: '/accessibility/keyboard/character-key-shortcuts',
-        text: '- Character key shortcuts'
-      },
-      {
-        href: '/accessibility/keyboard/pointer-gestures',
-        text: '- Pointer gestures'
-      },
-      {
-        href: '/accessibility/notifications',
-        text: 'Notifications'
-      },
-      {
-        href: '/accessibility/forms/keyboard',
-        text: '- Keyboard'
-      },
-      {
-        href: '/accessibility/timeouts',
-        text: 'Timeouts'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Written content</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/inclusive-language',
-          text: 'Inclusive language'
-        },
-        {
-          href: '/accessibility/readability',
-          text: 'Readability'
-        },
-      ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Providing alternatives</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/audio-and-video',
-          text: 'Audio and video'
-        },
-        {
-          href: '/accessibility/colour-and-contrast',
-          text: 'Colour and contrast'
-        },
-        {
-          href: '/accessibility/images',
-          text: 'Images'
-        },
-        {
-          href: '/accessibility/moving-and-flashing-content',
-          text: 'Moving and flashing content'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/standard',
-            text: 'Accessibility Standard'
-          },
-          {
-            href: '/accessibility/standard/perceivable',
-            text: '- Perceivable'
-          },
-          {
-            href: '/accessibility/standard/operable',
-            text: '- Operable'
-          },
-          {
-            href: '/accessibility/standard/understandable',
-            text: '- Understandable'
-          },
-          {
-            href: '/accessibility/standard/robust',
-            text: '- Robust'
-          },
-          {
-            href: '/accessibility/standard/meet-user-needs',
-            text: '- Meet user needs'
-          },
-          {
-            href: '/accessibility/resources',
-            text: 'Guidance, tools and further reading'
-          }
-        ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
 

--- a/apps/docs/src/common/pages/accessibility/standard/perceivable.tsx
+++ b/apps/docs/src/common/pages/accessibility/standard/perceivable.tsx
@@ -1,7 +1,8 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../../accessibility'
 
 export const title = 'Perceivable';
 const description = 'Perceivable Accessibility Standard requirements';
@@ -17,133 +18,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/headings',
-        text: 'Headings'
-      },
-      {
-        href: '/accessibility/links',
-        text: 'Links'
-      },
-      {
-        href: '/accessibility/navigation',
-        text: 'Navigation'
-      },
-      {
-        href: '/accessibility/tables',
-        text: 'Tables'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Interactivity</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/error-messages',
-        text: 'Error messages'
-      },
-      {
-        href: '/accessibility/forms',
-        text: 'Forms'
-      },
-      {
-        href: '/accessibility/keyboard',
-        text: 'Keyboard basics'
-      },
-      {
-        href: '/accessibility/keyboard/tab-navigation',
-        text: '- Tab navigation'
-      },
-      {
-        href: '/accessibility/keyboard/focus',
-        text: '- Focus'
-      },
-      {
-        href: '/accessibility/keyboard/skip-to-content',
-        text: '- Skip to content links'
-      },
-      {
-        href: '/accessibility/keyboard/character-key-shortcuts',
-        text: '- Character key shortcuts'
-      },
-      {
-        href: '/accessibility/keyboard/pointer-gestures',
-        text: '- Pointer gestures'
-      },
-      {
-        href: '/accessibility/notifications',
-        text: 'Notifications'
-      },
-      {
-        href: '/accessibility/forms/keyboard',
-        text: '- Keyboard'
-      },
-      {
-        href: '/accessibility/timeouts',
-        text: 'Timeouts'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Written content</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/inclusive-language',
-          text: 'Inclusive language'
-        },
-        {
-          href: '/accessibility/readability',
-          text: 'Readability'
-        },
-      ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Providing alternatives</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/audio-and-video',
-          text: 'Audio and video'
-        },
-        {
-          href: '/accessibility/colour-and-contrast',
-          text: 'Colour and contrast'
-        },
-        {
-          href: '/accessibility/images',
-          text: 'Images'
-        },
-        {
-          href: '/accessibility/moving-and-flashing-content',
-          text: 'Moving and flashing content'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/standard',
-            text: 'Accessibility Standard'
-          },
-          {
-            href: '/accessibility/standard/perceivable',
-            text: '- Perceivable'
-          },
-          {
-            href: '/accessibility/standard/operable',
-            text: '- Operable'
-          },
-          {
-            href: '/accessibility/standard/understandable',
-            text: '- Understandable'
-          },
-          {
-            href: '/accessibility/standard/robust',
-            text: '- Robust'
-          },
-          {
-            href: '/accessibility/standard/meet-user-needs',
-            text: '- Meet user needs'
-          },
-          {
-            href: '/accessibility/resources',
-            text: 'Guidance, tools and further reading'
-          }
-        ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
 

--- a/apps/docs/src/common/pages/accessibility/standard/robust.tsx
+++ b/apps/docs/src/common/pages/accessibility/standard/robust.tsx
@@ -1,7 +1,8 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../../accessibility'
 
 export const title = 'Robust';
 const description = 'Robust Accessibility Standard requirements';
@@ -17,133 +18,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/headings',
-        text: 'Headings'
-      },
-      {
-        href: '/accessibility/links',
-        text: 'Links'
-      },
-      {
-        href: '/accessibility/navigation',
-        text: 'Navigation'
-      },
-      {
-        href: '/accessibility/tables',
-        text: 'Tables'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Interactivity</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/error-messages',
-        text: 'Error messages'
-      },
-      {
-        href: '/accessibility/forms',
-        text: 'Forms'
-      },
-      {
-        href: '/accessibility/keyboard',
-        text: 'Keyboard basics'
-      },
-      {
-        href: '/accessibility/keyboard/tab-navigation',
-        text: '- Tab navigation'
-      },
-      {
-        href: '/accessibility/keyboard/focus',
-        text: '- Focus'
-      },
-      {
-        href: '/accessibility/keyboard/skip-to-content',
-        text: '- Skip to content links'
-      },
-      {
-        href: '/accessibility/keyboard/character-key-shortcuts',
-        text: '- Character key shortcuts'
-      },
-      {
-        href: '/accessibility/keyboard/pointer-gestures',
-        text: '- Pointer gestures'
-      },
-      {
-        href: '/accessibility/notifications',
-        text: 'Notifications'
-      },
-      {
-        href: '/accessibility/forms/keyboard',
-        text: '- Keyboard'
-      },
-      {
-        href: '/accessibility/timeouts',
-        text: 'Timeouts'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Written content</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/inclusive-language',
-          text: 'Inclusive language'
-        },
-        {
-          href: '/accessibility/readability',
-          text: 'Readability'
-        },
-      ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Providing alternatives</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/audio-and-video',
-          text: 'Audio and video'
-        },
-        {
-          href: '/accessibility/colour-and-contrast',
-          text: 'Colour and contrast'
-        },
-        {
-          href: '/accessibility/images',
-          text: 'Images'
-        },
-        {
-          href: '/accessibility/moving-and-flashing-content',
-          text: 'Moving and flashing content'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/standard',
-            text: 'Accessibility Standard'
-          },
-          {
-            href: '/accessibility/standard/perceivable',
-            text: '- Perceivable'
-          },
-          {
-            href: '/accessibility/standard/operable',
-            text: '- Operable'
-          },
-          {
-            href: '/accessibility/standard/understandable',
-            text: '- Understandable'
-          },
-          {
-            href: '/accessibility/standard/robust',
-            text: '- Robust'
-          },
-          {
-            href: '/accessibility/standard/meet-user-needs',
-            text: '- Meet user needs'
-          },
-          {
-            href: '/accessibility/resources',
-            text: 'Guidance, tools and further reading'
-          }
-        ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
 

--- a/apps/docs/src/common/pages/accessibility/standard/understandable.tsx
+++ b/apps/docs/src/common/pages/accessibility/standard/understandable.tsx
@@ -1,7 +1,8 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../../accessibility'
 
 export const title = 'Understandable';
 const description = 'Understandable Accessibility Standard requirements';
@@ -17,133 +18,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/headings',
-        text: 'Headings'
-      },
-      {
-        href: '/accessibility/links',
-        text: 'Links'
-      },
-      {
-        href: '/accessibility/navigation',
-        text: 'Navigation'
-      },
-      {
-        href: '/accessibility/tables',
-        text: 'Tables'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Interactivity</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/error-messages',
-        text: 'Error messages'
-      },
-      {
-        href: '/accessibility/forms',
-        text: 'Forms'
-      },
-      {
-        href: '/accessibility/keyboard',
-        text: 'Keyboard basics'
-      },
-      {
-        href: '/accessibility/keyboard/tab-navigation',
-        text: '- Tab navigation'
-      },
-      {
-        href: '/accessibility/keyboard/focus',
-        text: '- Focus'
-      },
-      {
-        href: '/accessibility/keyboard/skip-to-content',
-        text: '- Skip to content links'
-      },
-      {
-        href: '/accessibility/keyboard/character-key-shortcuts',
-        text: '- Character key shortcuts'
-      },
-      {
-        href: '/accessibility/keyboard/pointer-gestures',
-        text: '- Pointer gestures'
-      },
-      {
-        href: '/accessibility/notifications',
-        text: 'Notifications'
-      },
-      {
-        href: '/accessibility/forms/keyboard',
-        text: '- Keyboard'
-      },
-      {
-        href: '/accessibility/timeouts',
-        text: 'Timeouts'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Written content</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/inclusive-language',
-          text: 'Inclusive language'
-        },
-        {
-          href: '/accessibility/readability',
-          text: 'Readability'
-        },
-      ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Providing alternatives</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/audio-and-video',
-          text: 'Audio and video'
-        },
-        {
-          href: '/accessibility/colour-and-contrast',
-          text: 'Colour and contrast'
-        },
-        {
-          href: '/accessibility/images',
-          text: 'Images'
-        },
-        {
-          href: '/accessibility/moving-and-flashing-content',
-          text: 'Moving and flashing content'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/standard',
-            text: 'Accessibility Standard'
-          },
-          {
-            href: '/accessibility/standard/perceivable',
-            text: '- Perceivable'
-          },
-          {
-            href: '/accessibility/standard/operable',
-            text: '- Operable'
-          },
-          {
-            href: '/accessibility/standard/understandable',
-            text: '- Understandable'
-          },
-          {
-            href: '/accessibility/standard/robust',
-            text: '- Robust'
-          },
-          {
-            href: '/accessibility/standard/meet-user-needs',
-            text: '- Meet user needs'
-          },
-          {
-            href: '/accessibility/resources',
-            text: 'Guidance, tools and further reading'
-          }
-        ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
 

--- a/apps/docs/src/common/pages/accessibility/tables.tsx
+++ b/apps/docs/src/common/pages/accessibility/tables.tsx
@@ -1,8 +1,8 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
-import { Table } from '@not-govuk/components';
+import { A, Table } from '@not-govuk/components';
+import { menu } from '../accessibility'
 
 const tables = require('../../../../assets/images/accessibility/tables.png').default;
 
@@ -20,137 +20,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/headings',
-        text: 'Headings'
-      },
-      {
-        href: '/accessibility/layout-typography',
-        text: 'Layout and typography'
-      },
-      {
-        href: '/accessibility/links',
-        text: 'Links'
-      },
-      {
-        href: '/accessibility/navigation',
-        text: 'Navigation'
-      },
-      {
-        href: '/accessibility/tables',
-        text: 'Tables'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Interactivity</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/error-messages',
-        text: 'Error messages'
-      },
-      {
-        href: '/accessibility/forms',
-        text: 'Forms'
-      },
-      {
-        href: '/accessibility/keyboard',
-        text: 'Keyboard basics'
-      },
-      {
-        href: '/accessibility/keyboard/tab-navigation',
-        text: '- Tab navigation'
-      },
-      {
-        href: '/accessibility/keyboard/focus',
-        text: '- Focus'
-      },
-      {
-        href: '/accessibility/keyboard/skip-to-content',
-        text: '- Skip to content links'
-      },
-      {
-        href: '/accessibility/keyboard/character-key-shortcuts',
-        text: '- Character key shortcuts'
-      },
-      {
-        href: '/accessibility/keyboard/pointer-gestures',
-        text: '- Pointer gestures'
-      },
-      {
-        href: '/accessibility/notifications',
-        text: 'Notifications'
-      },
-      {
-        href: '/accessibility/forms/keyboard',
-        text: '- Keyboard'
-      },
-      {
-        href: '/accessibility/timeouts',
-        text: 'Timeouts'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Written content</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/inclusive-language',
-          text: 'Inclusive language'
-        },
-        {
-          href: '/accessibility/readability',
-          text: 'Readability'
-        }
-      ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Providing alternatives</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/audio-and-video',
-          text: 'Audio and video'
-        },
-        {
-          href: '/accessibility/colour-and-contrast',
-          text: 'Colour and contrast'
-        },
-        {
-          href: '/accessibility/images',
-          text: 'Images'
-        },
-        {
-          href: '/accessibility/moving-and-flashing-content',
-          text: 'Moving and flashing content'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/standard',
-            text: 'Accessibility Standard'
-          },
-          {
-            href: '/accessibility/standard/perceivable',
-            text: '- Perceivable'
-          },
-          {
-            href: '/accessibility/standard/operable',
-            text: '- Operable'
-          },
-          {
-            href: '/accessibility/standard/understandable',
-            text: '- Understandable'
-          },
-          {
-            href: '/accessibility/standard/robust',
-            text: '- Robust'
-          },
-          {
-            href: '/accessibility/standard/meet-user-needs',
-            text: '- Meet user needs'
-          },
-          {
-            href: '/accessibility/resources',
-            text: 'Guidance, tools and further reading'
-          }
-        ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>

--- a/apps/docs/src/common/pages/accessibility/template.tsx
+++ b/apps/docs/src/common/pages/accessibility/template.tsx
@@ -1,7 +1,8 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../accessibility'
 
 const linksImage01 = require('../../../../assets/images/accessibility/links01.png').default;
 
@@ -19,155 +20,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/#',
-          text: 'Headings - TBD'
-        },
-        {
-          href: '/accessibility/links',
-          text: 'Links'
-        },
-        {
-          href: '/accessibility/#',
-          text: 'Navigation - TBD'
-        },
-        {
-          href: '/accessibility/tables',
-          text: 'Tables'
-        },
-        {
-          href: '/accessibility/headings',
-          text: 'Headings'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Interactivity</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/#',
-            text: 'Dynamic content - TBD'
-          },
-          {
-            href: '/accessibility/error-messages',
-            text: 'Error messages'
-          },
-          {
-            href: '/accessibility/keyboard',
-            text: 'Keyboard basics'
-          },
-          {
-            href: '/accessibility/keyboard/tab-navigation',
-            text: '- Tab navigation'
-          },
-          {
-            href: '/accessibility/keyboard/focus',
-            text: '- Focus'
-          },
-          {
-            href: '/accessibility/keyboard/skip-to-content',
-            text: '- Skip to content links'
-          },
-          {
-            href: '/accessibility/keyboard/character-key-shortcuts',
-            text: '- Character key shortcuts'
-          },
-          {
-            href: '/accessibility/keyboard/pointer-gestures',
-            text: '- Pointer gestures'
-          },
-          {
-            href: '/accessibility/#',
-            text: 'Forms - TBD'
-          },
-          {
-            href: '/accessibility/#',
-            text: 'Surprises - TBD'
-          },
-          {
-            href: '/accessibility/#',
-            text: 'Timeouts - TBD'
-          },
-          {
-            href: '/accessibility/layout-typography',
-            text: 'Layout and typography'
-          }
-        ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Written content</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/#',
-            text: 'Inclusive language'
-          },
-          {
-            href: '/accessibility/#',
-            text: 'Readability - TBD'
-          },
-          {
-            href: '/accessibility/#',
-            text: 'Text and zoom - TBD'
-          }
-        ]} />
-        <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Providing alternatives</span>
-          <NavigationMenu items={[
-            {
-              href: '/accessibility/audio-and-video',
-              text: 'Audio and video'
-            },
-            {
-              href: '/accessibility/#',
-              text: 'Colour and contrast - TBD'
-            },
-            {
-              href: '/accessibility/images',
-              text: 'Images'
-            },
-            {
-              href: '/accessibility/#',
-              text: 'Moving content - TBD'
-            }
-          ]} />
-          <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Legal obligations</span>
-            <NavigationMenu items={[
-              {
-                href: '/accessibility/#',
-                text: 'Accessibility statement - TBD'
-              },
-              {
-                href: '/accessibility/#',
-                text: 'Disproportionate burden - TBD'
-              },
-              {
-                href: '/accessibility/#',
-                text: 'Equality act / PSED - TBD'
-              },
-              {
-                href: '/accessibility/#',
-                text: 'PSBAR - TBD'
-              }
-            ]} />
-            <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Accessible documents</span>
-              <NavigationMenu items={[
-                {
-                  href: '/accessibility/#',
-                  text: 'Accessible PDFs - TBD'
-                },
-                {
-                  href: '/accessibility/#',
-                  text: 'Emails - TBD'
-                },
-                {
-                  href: '/accessibility/#',
-                  text: 'Sharepoint - TBD'
-                }
-              ]} />
-        <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Resources</span>
-          <NavigationMenu items={[
-            {
-              href: '/accessibility/resources',
-              text: 'Guidance, tools and further reading'
-            }
-          ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>

--- a/apps/docs/src/common/pages/accessibility/timeouts.tsx
+++ b/apps/docs/src/common/pages/accessibility/timeouts.tsx
@@ -1,7 +1,8 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../accessibility'
 
 const applyModalWindow = require('../../../../assets/images/patterns/timeout.svg').default;
 
@@ -19,137 +20,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Page structure</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/headings',
-        text: 'Headings'
-      },
-      {
-        href: '/accessibility/layout-typography',
-        text: 'Layout and typography'
-      },
-      {
-        href: '/accessibility/links',
-        text: 'Links'
-      },
-      {
-        href: '/accessibility/navigation',
-        text: 'Navigation'
-      },
-      {
-        href: '/accessibility/tables',
-        text: 'Tables'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Interactivity</span>
-    <NavigationMenu items={[
-      {
-        href: '/accessibility/error-messages',
-        text: 'Error messages'
-      },
-      {
-        href: '/accessibility/forms',
-        text: 'Forms'
-      },
-      {
-        href: '/accessibility/keyboard',
-        text: 'Keyboard basics'
-      },
-      {
-        href: '/accessibility/keyboard/tab-navigation',
-        text: '- Tab navigation'
-      },
-      {
-        href: '/accessibility/keyboard/focus',
-        text: '- Focus'
-      },
-      {
-        href: '/accessibility/keyboard/skip-to-content',
-        text: '- Skip to content links'
-      },
-      {
-        href: '/accessibility/keyboard/character-key-shortcuts',
-        text: '- Character key shortcuts'
-      },
-      {
-        href: '/accessibility/keyboard/pointer-gestures',
-        text: '- Pointer gestures'
-      },
-      {
-        href: '/accessibility/notifications',
-        text: 'Notifications'
-      },
-      {
-        href: '/accessibility/forms/keyboard',
-        text: '- Keyboard'
-      },
-      {
-        href: '/accessibility/timeouts',
-        text: 'Timeouts'
-      }
-    ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Written content</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/inclusive-language',
-          text: 'Inclusive language'
-        },
-        {
-          href: '/accessibility/readability',
-          text: 'Readability'
-        }
-      ]} />
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Providing alternatives</span>
-      <NavigationMenu items={[
-        {
-          href: '/accessibility/audio-and-video',
-          text: 'Audio and video'
-        },
-        {
-          href: '/accessibility/colour-and-contrast',
-          text: 'Colour and contrast'
-        },
-        {
-          href: '/accessibility/images',
-          text: 'Images'
-        },
-        {
-          href: '/accessibility/moving-and-flashing-content',
-          text: 'Moving and flashing content'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/accessibility/standard',
-            text: 'Accessibility Standard'
-          },
-          {
-            href: '/accessibility/standard/perceivable',
-            text: '- Perceivable'
-          },
-          {
-            href: '/accessibility/standard/operable',
-            text: '- Operable'
-          },
-          {
-            href: '/accessibility/standard/understandable',
-            text: '- Understandable'
-          },
-          {
-            href: '/accessibility/standard/robust',
-            text: '- Robust'
-          },
-          {
-            href: '/accessibility/standard/meet-user-needs',
-            text: '- Meet user needs'
-          },
-          {
-            href: '/accessibility/resources',
-            text: 'Guidance, tools and further reading'
-          }
-        ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>

--- a/apps/docs/src/common/pages/get-involved.tsx
+++ b/apps/docs/src/common/pages/get-involved.tsx
@@ -1,7 +1,42 @@
-import { FC, createElement as h } from 'react';
+import { FC, Fragment, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
 import { A, NavigationMenu } from '@not-govuk/components';
+
+export const menu = (
+  <Fragment>
+    <NavigationMenu items={[
+      {
+        href: '/get-involved/working',
+        text: 'Working group'
+      },
+      {
+        href: '/get-involved/backlog',
+        text: 'Backlog'
+      },
+      {
+        href: '/get-involved/suggest',
+        text: 'Suggest new ideas'
+      },
+      {
+        href: '/get-involved/contribution',
+        text: 'Contribution criteria'
+      },
+      {
+        href: '/get-involved/githubguide',
+        text: 'Using GitHub to propose design system changes'
+      },
+      {
+        href: '/get-involved/proving',
+        text: 'Proving ideas work'
+      },
+      {
+        href: '/get-involved/using',
+        text: 'Using the system'
+      }
+    ]} />
+  </Fragment>
+);
 
 export const title = 'Get involved';
 const description = 'How to get involved and contribute to the Home Office Design System'
@@ -16,36 +51,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={title} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-      <NavigationMenu items={[
-        {
-          href: '/get-involved/working',
-          text: 'Working group'
-        },
-        {
-          href: '/get-involved/backlog',
-          text: 'Backlog'
-        },
-        {
-          href: '/get-involved/suggest',
-          text: 'Suggest new ideas'
-        },
-        {
-          href: '/get-involved/contribution',
-          text: 'Contribution criteria'
-        },
-        {
-          href: '/get-involved/githubguide',
-          text: 'Using GitHub to propose design system changes'
-        },
-        {
-          href: '/get-involved/proving',
-          text: 'Proving ideas work'
-        },
-        {
-          href: '/get-involved/using',
-          text: 'Using the system'
-        }
-      ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
     <h1 className="heading-section">Get involved</h1>

--- a/apps/docs/src/common/pages/get-involved/backlog.tsx
+++ b/apps/docs/src/common/pages/get-involved/backlog.tsx
@@ -1,7 +1,8 @@
-import { FC, Fragment, createElement as h } from 'react';
+import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../get-involved';
 
 export const title = 'Backlog';
 const description = 'How to get involved and contribute to the Home Office Design System'
@@ -17,36 +18,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-      <NavigationMenu items={[
-        {
-          href: '/get-involved/working',
-          text: 'Working group'
-        },
-        {
-          href: '/get-involved/backlog',
-          text: 'Backlog'
-        },
-        {
-          href: '/get-involved/suggest',
-          text: 'Suggest new ideas'
-        },
-        {
-          href: '/get-involved/contribution',
-          text: 'Contribution criteria'
-        },
-        {
-          href: '/get-involved/githubguide',
-          text: 'Using GitHub to propose design system changes'
-        },
-        {
-          href: '/get-involved/proving',
-          text: 'Proving ideas work'
-        },
-        {
-          href: '/get-involved/using',
-          text: 'Using the system'
-        }
-      ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>

--- a/apps/docs/src/common/pages/get-involved/contribution.tsx
+++ b/apps/docs/src/common/pages/get-involved/contribution.tsx
@@ -1,7 +1,8 @@
-import { FC, Fragment, createElement as h } from 'react';
+import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../get-involved';
 
 export const title = 'Contribution criteria';
 const description = 'How to contribute your work to the Home Office design system'
@@ -17,36 +18,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-      <NavigationMenu items={[
-        {
-          href: '/get-involved/working',
-          text: 'Working group'
-        },
-        {
-          href: '/get-involved/backlog',
-          text: 'Backlog'
-        },
-        {
-          href: '/get-involved/suggest',
-          text: 'Suggest new ideas'
-        },
-        {
-          href: '/get-involved/contribution',
-          text: 'Contribution criteria'
-        },
-        {
-          href: '/get-involved/githubguide',
-          text: 'Using GitHub to propose design system changes'
-        },
-        {
-          href: '/get-involved/proving',
-          text: 'Proving ideas work'
-        },
-        {
-          href: '/get-involved/using',
-          text: 'Using the system'
-        }
-      ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>

--- a/apps/docs/src/common/pages/get-involved/githubguide.tsx
+++ b/apps/docs/src/common/pages/get-involved/githubguide.tsx
@@ -1,7 +1,8 @@
-import { FC, Fragment, createElement as h } from 'react';
+import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../get-involved';
 
 const applyGithub1 = require('../../../../assets/images/Github-guide-screen-1.png').default;
 const applyGithub2 = require('../../../../assets/images/Github-guide-screen-2.png').default;
@@ -24,36 +25,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-      <NavigationMenu items={[
-        {
-          href: '/get-involved/working',
-          text: 'Working group'
-        },
-        {
-          href: '/get-involved/backlog',
-          text: 'Backlog'
-        },
-        {
-          href: '/get-involved/suggest',
-          text: 'Suggest new ideas'
-        },
-        {
-          href: '/get-involved/contribution',
-          text: 'Contribution criteria'
-        },
-        {
-          href: '/get-involved/githubguide',
-          text: 'Using GitHub to propose design system changes'
-        },
-        {
-          href: '/get-involved/proving',
-          text: 'Proving ideas work'
-        },
-        {
-          href: '/get-involved/using',
-          text: 'Using the system'
-        }
-      ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>

--- a/apps/docs/src/common/pages/get-involved/proving.tsx
+++ b/apps/docs/src/common/pages/get-involved/proving.tsx
@@ -1,7 +1,8 @@
-import { FC, Fragment, createElement as h } from 'react';
+import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../get-involved';
 
 export const title = 'Proving a pattern or component works';
 const description = 'The process a new pattern or component must go through.'
@@ -17,36 +18,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-      <NavigationMenu items={[
-        {
-          href: '/get-involved/working',
-          text: 'Working group'
-        },
-        {
-          href: '/get-involved/backlog',
-          text: 'Backlog'
-        },
-        {
-          href: '/get-involved/suggest',
-          text: 'Suggest new ideas'
-        },
-        {
-          href: '/get-involved/contribution',
-          text: 'Contribution criteria'
-        },
-        {
-          href: '/get-involved/githubguide',
-          text: 'Using GitHub to propose design system changes'
-        },
-        {
-          href: '/get-involved/proving',
-          text: 'Proving ideas work'
-        },
-        {
-          href: '/get-involved/using',
-          text: 'Using the system'
-        }
-      ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
 

--- a/apps/docs/src/common/pages/get-involved/suggest.tsx
+++ b/apps/docs/src/common/pages/get-involved/suggest.tsx
@@ -1,7 +1,8 @@
-import { FC, Fragment, createElement as h } from 'react';
+import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../get-involved';
 
 export const title = 'Suggest a new pattern or component';
 const description = 'How to propose a new pattern of component should be included in the Home Office Design System'
@@ -17,36 +18,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-      <NavigationMenu items={[
-        {
-          href: '/get-involved/working',
-          text: 'Working group'
-        },
-        {
-          href: '/get-involved/backlog',
-          text: 'Backlog'
-        },
-        {
-          href: '/get-involved/suggest',
-          text: 'Suggest new ideas'
-        },
-        {
-          href: '/get-involved/contribution',
-          text: 'Contribution criteria'
-        },
-        {
-          href: '/get-involved/githubguide',
-          text: 'Using GitHub to propose design system changes'
-        },
-        {
-          href: '/get-involved/proving',
-          text: 'Proving ideas work'
-        },
-        {
-          href: '/get-involved/using',
-          text: 'Using the system'
-        }
-      ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>

--- a/apps/docs/src/common/pages/get-involved/using.tsx
+++ b/apps/docs/src/common/pages/get-involved/using.tsx
@@ -1,7 +1,8 @@
-import { FC, Fragment, createElement as h } from 'react';
+import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../get-involved';
 
 export const title = 'Using the design system';
 const description = 'How to use the Home Office Design System'
@@ -17,36 +18,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-      <NavigationMenu items={[
-        {
-          href: '/get-involved/working',
-          text: 'Working group'
-        },
-        {
-          href: '/get-involved/backlog',
-          text: 'Backlog'
-        },
-        {
-          href: '/get-involved/suggest',
-          text: 'Suggest new ideas'
-        },
-        {
-          href: '/get-involved/contribution',
-          text: 'Contribution criteria'
-        },
-        {
-          href: '/get-involved/githubguide',
-          text: 'Using GitHub to propose design system changes'
-        },
-        {
-          href: '/get-involved/proving',
-          text: 'Proving ideas work'
-        },
-        {
-          href: '/get-involved/using',
-          text: 'Using the system'
-        }
-      ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>

--- a/apps/docs/src/common/pages/get-involved/working.tsx
+++ b/apps/docs/src/common/pages/get-involved/working.tsx
@@ -1,7 +1,8 @@
-import { FC, Fragment, createElement as h } from 'react';
+import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../get-involved';
 
 export const title = 'Design system working group';
 const description = 'The Home Office design system working group meets once a month to discuss ways to develop and improve the Home Office design system';
@@ -17,36 +18,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-      <NavigationMenu items={[
-        {
-          href: '/get-involved/working',
-          text: 'Working group'
-        },
-        {
-          href: '/get-involved/backlog',
-          text: 'Backlog'
-        },
-        {
-          href: '/get-involved/suggest',
-          text: 'Suggest new ideas'
-        },
-        {
-          href: '/get-involved/contribution',
-          text: 'Contribution criteria'
-        },
-        {
-          href: '/get-involved/githubguide',
-          text: 'Using GitHub to propose design system changes'
-        },
-        {
-          href: '/get-involved/proving',
-          text: 'Proving ideas work'
-        },
-        {
-          href: '/get-involved/using',
-          text: 'Using the system'
-        }
-      ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>

--- a/apps/docs/src/common/pages/get-started.tsx
+++ b/apps/docs/src/common/pages/get-started.tsx
@@ -1,7 +1,34 @@
-import { FC, createElement as h } from 'react';
+import { FC, Fragment, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
 import { A, NavigationMenu } from '@not-govuk/components';
+
+export const menu = (
+  <Fragment>
+    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>How to guides</span>
+    <NavigationMenu items={[
+      {
+        href: '/get-started/prototyping',
+        text: 'Prototyping'
+      },
+      {
+        href: '/get-started/start-prototype',
+        text: '- Setting up your prototype'
+      },
+      {
+        href: '/get-started/use-prototype',
+        text: '- Building your protoype'
+      }
+    ]} />
+    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Community resources</span>
+    <NavigationMenu items={[
+      {
+        href: '/get-started/design-assets',
+        text: 'Design assets'
+      }
+    ]} />
+  </Fragment>
+);
 
 export const title = 'Get started';
 const description = 'The following introductory guides will help you to get set up';
@@ -16,31 +43,8 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={title} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>How to guides</span>
-      <NavigationMenu items={[
-        {
-          href: '/get-started/prototyping',
-          text: 'Prototyping'
-        },
-        {
-          href: '/get-started/start-prototype',
-          text: '- Setting up your prototype'
-        },
-        {
-          href: '/get-started/use-prototype',
-          text: '- Building your protoype'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Community resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/get-started/design-assets',
-            text: 'Design assets'
-          }
-        ]} />
-
+      {menu}
     </div>
-
     <div className="govuk-grid-column-three-quarters">
       <h1>{title}</h1>
         <p>The Home Office Design System is an extension of <A href="https://not-gov.uk/">NotGovUK</A> which implements the GOV.UK Design System in React. (See: <A href="https://not-gov.uk/design-decisions">design decisions</A>)</p>

--- a/apps/docs/src/common/pages/get-started/deploy-prototype.tsx
+++ b/apps/docs/src/common/pages/get-started/deploy-prototype.tsx
@@ -1,16 +1,18 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
-
-const applyPrototype7 = require('../../../../assets/images/heroku2.png').default;
-const applyPrototype8 = require('../../../../assets/images/heroku3.png').default;
-const applyPrototype9 = require('../../../../assets/images/heroku4.png').default;
+import { A } from '@not-govuk/components';
+import { menu } from '../get-started';
 
 export const title = 'Deploying your prototype';
 const description = 'How to deploy your prototype';
 const section = 'Get started';
 const subsection = 'Prototyping';
+
+const applyPrototype7 = require('../../../../assets/images/heroku2.png').default;
+const applyPrototype8 = require('../../../../assets/images/heroku3.png').default;
+const applyPrototype9 = require('../../../../assets/images/heroku4.png').default;
+
 
 const Page: FC<PageProps> = ({ location }) => (
   <div className="govuk-grid-row">
@@ -22,32 +24,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>How to guides</span>
-      <NavigationMenu items={[
-        {
-          href: '/get-started/prototyping',
-          text: 'Prototyping'
-        },
-        {
-          href: '/get-started/start-prototype',
-          text: '- Starting your prototype'
-        },
-        {
-          href: '/get-started/use-prototype',
-          text: '- Building your protoype'
-        },
-        {
-          href: '/get-started/deploy-prototype',
-          text: '- Deploying your prototype'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Community resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/get-started/design-assets',
-            text: 'Design assets'
-          }
-        ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>

--- a/apps/docs/src/common/pages/get-started/design-assets.tsx
+++ b/apps/docs/src/common/pages/get-started/design-assets.tsx
@@ -1,7 +1,8 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../get-started';
 
 export const title = 'Design assets';
 const description = 'Useful design assets for interaction designers in the Home Office';
@@ -17,28 +18,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>How to guides</span>
-      <NavigationMenu items={[
-        {
-          href: '/get-started/prototyping',
-          text: 'Prototyping'
-        },
-        {
-          href: '/get-started/start-prototype',
-          text: '- Setting up your prototype'
-        },
-        {
-          href: '/get-started/use-prototype',
-          text: '- Building your protoype'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Community resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/get-started/design-assets',
-            text: 'Design assets'
-          }
-        ]} />
+      {menu}
     </div>
 
     <div className="govuk-grid-column-three-quarters">

--- a/apps/docs/src/common/pages/get-started/project.tsx
+++ b/apps/docs/src/common/pages/get-started/project.tsx
@@ -1,7 +1,8 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../get-started';
 
 export const title = 'Production';
 const longTitle = 'Starting a new project';
@@ -18,28 +19,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>How to guides</span>
-      <NavigationMenu items={[
-        {
-          href: '/get-started/prototyping',
-          text: 'Prototyping'
-        },
-        {
-          href: '/get-started/start-prototype',
-          text: '- Setting up your prototype'
-        },
-        {
-          href: '/get-started/use-prototype',
-          text: '- Building your protoype'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Community resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/get-started/design-assets',
-            text: 'Design assets'
-          }
-        ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>

--- a/apps/docs/src/common/pages/get-started/prototyping.tsx
+++ b/apps/docs/src/common/pages/get-started/prototyping.tsx
@@ -1,7 +1,8 @@
 import { FC, Fragment, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../get-started';
 
 export const title = 'Prototyping';
 const description = 'How to prototype with the Home Office Design System';
@@ -17,28 +18,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>How to guides</span>
-      <NavigationMenu items={[
-        {
-          href: '/get-started/prototyping',
-          text: 'Prototyping'
-        },
-        {
-          href: '/get-started/start-prototype',
-          text: '- Setting up your prototype'
-        },
-        {
-          href: '/get-started/use-prototype',
-          text: '- Building your protoype'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Community resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/get-started/design-assets',
-            text: 'Design assets'
-          }
-        ]} />
+      {menu}
     </div>
 
     <div className="govuk-grid-column-three-quarters">

--- a/apps/docs/src/common/pages/get-started/start-prototype.tsx
+++ b/apps/docs/src/common/pages/get-started/start-prototype.tsx
@@ -1,7 +1,13 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../get-started';
+
+export const title = 'Setting up your prototype';
+const description = 'How to generate a new prototype based on the Home Office Design System';
+const section = 'Get started';
+const subsection = 'Prototyping';
 
 const applyPrototype0 = require('../../../../assets/images/github-screen01.png').default;
 const applyPrototype1 = require('../../../../assets/images/terminal-screen01.png').default;
@@ -10,10 +16,6 @@ const applyPrototype3a = require('../../../../assets/images/github-screen02.png'
 const applyPrototype7 = require('../../../../assets/images/heroku02.png').default;
 const applyPrototype9 = require('../../../../assets/images/heroku4.png').default;
 
-export const title = 'Setting up your prototype';
-const description = 'How to generate a new prototype based on the Home Office Design System';
-const section = 'Get started';
-const subsection = 'Prototyping';
 
 const Page: FC<PageProps> = ({ location }) => (
   <div className="govuk-grid-row">
@@ -25,28 +27,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>How to guides</span>
-      <NavigationMenu items={[
-        {
-          href: '/get-started/prototyping',
-          text: 'Prototyping'
-        },
-        {
-          href: '/get-started/start-prototype',
-          text: '- Setting up your prototype'
-        },
-        {
-          href: '/get-started/use-prototype',
-          text: '- Building your protoype'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Community resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/get-started/design-assets',
-            text: 'Design assets'
-          }
-        ]} />
+      {menu}
     </div>
 
     <div className="govuk-grid-column-three-quarters">

--- a/apps/docs/src/common/pages/get-started/use-prototype.tsx
+++ b/apps/docs/src/common/pages/get-started/use-prototype.tsx
@@ -1,7 +1,13 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../get-started';
+
+export const title = 'Building your prototype';
+const description = 'How to build your prototype';
+const section = 'Get started';
+const subsection = 'Prototyping';
 
 const applyPrototype3 = require('../../../../assets/images/prototype-screen03.png').default;
 const applyPrototype4 = require('../../../../assets/images/prototype-screen04html.png').default;
@@ -10,10 +16,6 @@ const applyPrototype6 = require('../../../../assets/images/prototype-screen07.pn
 const applyPrototype8 = require('../../../../assets/images/prototype-screen08.png').default;
 const applyPrototype9 = require('../../../../assets/images/prototype-screen09.png').default;
 
-export const title = 'Building your prototype';
-const description = 'How to build your prototype';
-const section = 'Get started';
-const subsection = 'Prototyping';
 
 const Page: FC<PageProps> = ({ location }) => (
   <div className="govuk-grid-row">
@@ -25,28 +27,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>How to guides</span>
-      <NavigationMenu items={[
-        {
-          href: '/get-started/prototyping',
-          text: 'Prototyping'
-        },
-        {
-          href: '/get-started/start-prototype',
-          text: '- Setting up your prototype'
-        },
-        {
-          href: '/get-started/use-prototype',
-          text: '- Building your protoype'
-        }
-      ]} />
-      <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Community resources</span>
-        <NavigationMenu items={[
-          {
-            href: '/get-started/design-assets',
-            text: 'Design assets'
-          }
-        ]} />
+      {menu}
     </div>
 
     <div className="govuk-grid-column-three-quarters">

--- a/apps/docs/src/common/pages/patterns.tsx
+++ b/apps/docs/src/common/pages/patterns.tsx
@@ -3,6 +3,43 @@ import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
 import { A, NavigationMenu } from '@not-govuk/components';
 
+export const menu = (
+  <Fragment>
+    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Help users to</span>
+    <NavigationMenu items={[
+
+      {
+        href: '/patterns/access-a-service',
+        text: 'Access a service'
+      },
+      {
+        href: '/patterns/add-multiple-things',
+        text: 'Add multiple things'
+      },
+      {
+        href: '/patterns/find-information-on-document',
+        text: 'Find information on a document'
+      },
+      {
+        href: '/patterns/get-more-details',
+        text: 'Get more details'
+      },
+      {
+        href: '/patterns/leave-a-service',
+        text: 'Leave a service'
+      },
+      {
+        href: '/patterns/stop-a-service-timing-out',
+        text: 'Stop a service timing out'
+      },
+      {
+        href: '/patterns/search-for-something',
+        text: 'Search for something'
+      }
+    ]} />
+  </Fragment>
+);
+
 export const title = 'Patterns';
 const description = 'Patterns are best practice design solutions for specific user-focused tasks and page types';
 
@@ -16,38 +53,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={title} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Help users to</span>
-      <NavigationMenu items={[
-
-        {
-          href: '/patterns/access-a-service',
-          text: 'Access a service'
-        },
-        {
-          href: '/patterns/add-multiple-things',
-          text: 'Add multiple things'
-        },
-        {
-          href: '/patterns/find-information-on-document',
-          text: 'Find information on a document'
-        },
-        {
-          href: '/patterns/get-more-details',
-          text: 'Get more details'
-        },
-        {
-          href: '/patterns/leave-a-service',
-          text: 'Leave a service'
-        },
-        {
-          href: '/patterns/stop-a-service-timing-out',
-          text: 'Stop a service timing out'
-        },
-        {
-          href: '/patterns/search-for-something',
-          text: 'Search for something'
-        }
-      ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>{title}</h1>

--- a/apps/docs/src/common/pages/patterns/access-a-service.tsx
+++ b/apps/docs/src/common/pages/patterns/access-a-service.tsx
@@ -1,16 +1,17 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
-
-const applyAuthenticatePersonal = require('../../../../assets/images/patterns/authenticate-personal.svg').default;
-const applyAuthenticateReference = require('../../../../assets/images/patterns/authenticate-reference.svg').default;
-const applyAuthenticateTwoFa = require('../../../../assets/images/patterns/authenticate-2fa.svg').default;
+import { A } from '@not-govuk/components';
+import { menu } from '../patterns';
 
 export const title = 'Access a service';
 const description = 'How to help users to access a service';
 const section = 'Patterns';
 const subsection = 'Help users to';
+
+const applyAuthenticatePersonal = require('../../../../assets/images/patterns/authenticate-personal.svg').default;
+const applyAuthenticateReference = require('../../../../assets/images/patterns/authenticate-reference.svg').default;
+const applyAuthenticateTwoFa = require('../../../../assets/images/patterns/authenticate-2fa.svg').default;
 
 const Page: FC<PageProps> = ({ location }) => (
 <div className="govuk-grid-row">
@@ -23,39 +24,7 @@ const Page: FC<PageProps> = ({ location }) => (
   </Helmet>
 
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Help users to</span>
-      <NavigationMenu items={[
-
-        {
-          href: '/patterns/access-a-service',
-          text: 'Access a service'
-        },
-        {
-          href: '/patterns/add-multiple-things',
-          text: 'Add multiple things'
-        },
-        {
-          href: '/patterns/find-information-on-document',
-          text: 'Find information on a document'
-        },
-        {
-          href: '/patterns/get-more-details',
-          text: 'Get more details'
-        },
-        {
-          href: '/patterns/leave-a-service',
-          text: 'Leave a service'
-        },
-        {
-          href: '/patterns/stop-a-service-timing-out',
-          text: 'Stop a service timing out'
-        },
-        {
-          href: '/patterns/search-for-something',
-          text: 'Search for something'
-        }
-
-      ]} />
+      {menu}
     </div>
 
     <div className="govuk-grid-column-three-quarters">

--- a/apps/docs/src/common/pages/patterns/add-multiple-things.tsx
+++ b/apps/docs/src/common/pages/patterns/add-multiple-things.tsx
@@ -1,14 +1,15 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
-
-const applyAddAnother = require('../../../../assets/images/patterns/add-another.svg').default;
+import { A } from '@not-govuk/components';
+import { menu } from '../patterns';
 
 export const title = 'Add multiple things';
 const description = 'How to help users to add multiple things';
 const section = 'Patterns';
 const subsection = 'Help users to';
+
+const applyAddAnother = require('../../../../assets/images/patterns/add-another.svg').default;
 
 const Page: FC<PageProps> = ({ location }) => (
 <div className="govuk-grid-row">
@@ -21,38 +22,7 @@ const Page: FC<PageProps> = ({ location }) => (
   </Helmet>
 
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Help users to</span>
-      <NavigationMenu items={[
-
-        {
-          href: '/patterns/access-a-service',
-          text: 'Access a service'
-        },
-        {
-          href: '/patterns/add-multiple-things',
-          text: 'Add multiple things'
-        },
-        {
-          href: '/patterns/find-information-on-document',
-          text: 'Find information on a document'
-        },
-        {
-          href: '/patterns/get-more-details',
-          text: 'Get more details'
-        },
-        {
-          href: '/patterns/leave-a-service',
-          text: 'Leave a service'
-        },
-        {
-          href: '/patterns/stop-a-service-timing-out',
-          text: 'Stop a service timing out'
-        },
-        {
-          href: '/patterns/search-for-something',
-          text: 'Search for something'
-        }
-      ]} />
+      {menu}
     </div>
 
     <div className="govuk-grid-column-three-quarters">

--- a/apps/docs/src/common/pages/patterns/find-information-on-document.tsx
+++ b/apps/docs/src/common/pages/patterns/find-information-on-document.tsx
@@ -1,15 +1,16 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
-
-const applyImageInline = require('../../../../assets/images/patterns/image-guidance-inline.svg').default;
-const applyImageRight = require('../../../../assets/images/patterns/image-guidance-right.svg').default;
+import { A } from '@not-govuk/components';
+import { menu } from '../patterns';
 
 export const title = 'Find information on a document';
 const description = 'How to help users to find information on a document';
 const section = 'Patterns';
 const subsection = 'Help users to';
+
+const applyImageInline = require('../../../../assets/images/patterns/image-guidance-inline.svg').default;
+const applyImageRight = require('../../../../assets/images/patterns/image-guidance-right.svg').default;
 
 const Page: FC<PageProps> = ({ location }) => (
 <div className="govuk-grid-row">
@@ -22,38 +23,7 @@ const Page: FC<PageProps> = ({ location }) => (
   </Helmet>
 
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Help users to</span>
-      <NavigationMenu items={[
-
-        {
-          href: '/patterns/access-a-service',
-          text: 'Access a service'
-        },
-        {
-          href: '/patterns/add-multiple-things',
-          text: 'Add multiple things'
-        },
-        {
-          href: '/patterns/find-information-on-document',
-          text: 'Find information on a document'
-        },
-        {
-          href: '/patterns/get-more-details',
-          text: 'Get more details'
-        },
-        {
-          href: '/patterns/leave-a-service',
-          text: 'Leave a service'
-        },
-        {
-          href: '/patterns/stop-a-service-timing-out',
-          text: 'Stop a service timing out'
-        },
-        {
-          href: '/patterns/search-for-something',
-          text: 'Search for something'
-        }
-      ]} />
+      {menu}
     </div>
 
     <div className="govuk-grid-column-three-quarters">

--- a/apps/docs/src/common/pages/patterns/get-more-details.tsx
+++ b/apps/docs/src/common/pages/patterns/get-more-details.tsx
@@ -1,14 +1,15 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
-
-const applyContextualHelp = require('../../../../assets/images/patterns/contextual-help.svg').default;
+import { A } from '@not-govuk/components';
+import { menu } from '../patterns';
 
 export const title = 'Get more details';
 const description = 'How to help users to get more details on something';
 const section = 'Patterns';
 const subsection = 'Help users to';
+
+const applyContextualHelp = require('../../../../assets/images/patterns/contextual-help.svg').default;
 
 const Page: FC<PageProps> = ({ location }) => (
 <div className="govuk-grid-row">
@@ -21,38 +22,7 @@ const Page: FC<PageProps> = ({ location }) => (
   </Helmet>
 
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Help users to</span>
-      <NavigationMenu items={[
-
-        {
-          href: '/patterns/access-a-service',
-          text: 'Access a service'
-        },
-        {
-          href: '/patterns/add-multiple-things',
-          text: 'Add multiple things'
-        },
-        {
-          href: '/patterns/find-information-on-document',
-          text: 'Find information on a document'
-        },
-        {
-          href: '/patterns/get-more-details',
-          text: 'Get more details'
-        },
-        {
-          href: '/patterns/leave-a-service',
-          text: 'Leave a service'
-        },
-        {
-          href: '/patterns/stop-a-service-timing-out',
-          text: 'Stop a service timing out'
-        },
-        {
-          href: '/patterns/search-for-something',
-          text: 'Search for something'
-        }
-      ]} />
+      {menu}
     </div>
 
     <div className="govuk-grid-column-three-quarters">

--- a/apps/docs/src/common/pages/patterns/leave-a-service.tsx
+++ b/apps/docs/src/common/pages/patterns/leave-a-service.tsx
@@ -1,15 +1,16 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
-
-const applyLeaveHeader = require('../../../../assets/images/patterns/leave-service-header.svg').default;
-const applyLeaveInline = require('../../../../assets/images/patterns/leave-service-inline.svg').default;
+import { A } from '@not-govuk/components';
+import { menu } from '../patterns';
 
 export const title = 'Leave a service';
 const description = 'How to help users to leave a service';
 const section = 'Patterns';
 const subsection = 'Help users to';
+
+const applyLeaveHeader = require('../../../../assets/images/patterns/leave-service-header.svg').default;
+const applyLeaveInline = require('../../../../assets/images/patterns/leave-service-inline.svg').default;
 
 const Page: FC<PageProps> = ({ location }) => (
 <div className="govuk-grid-row">
@@ -22,38 +23,7 @@ const Page: FC<PageProps> = ({ location }) => (
   </Helmet>
 
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Help users to</span>
-      <NavigationMenu items={[
-
-        {
-          href: '/patterns/access-a-service',
-          text: 'Access a service'
-        },
-        {
-          href: '/patterns/add-multiple-things',
-          text: 'Add multiple things'
-        },
-        {
-          href: '/patterns/find-information-on-document',
-          text: 'Find information on a document'
-        },
-        {
-          href: '/patterns/get-more-details',
-          text: 'Get more details'
-        },
-        {
-          href: '/patterns/leave-a-service',
-          text: 'Leave a service'
-        },
-        {
-          href: '/patterns/stop-a-service-timing-out',
-          text: 'Stop a service timing out'
-        },
-        {
-          href: '/patterns/search-for-something',
-          text: 'Search for something'
-        }
-      ]} />
+      {menu}
     </div>
 
     <div className="govuk-grid-column-three-quarters">

--- a/apps/docs/src/common/pages/patterns/search-for-something.tsx
+++ b/apps/docs/src/common/pages/patterns/search-for-something.tsx
@@ -1,15 +1,16 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
-
- const applySearchNarrow = require('../../../../assets/images/patterns/search-narrow.svg').default;
- const applySearchWide= require('../../../../assets/images/patterns/search-wide.svg').default;
+import { A } from '@not-govuk/components';
+import { menu } from '../patterns';
 
 export const title = 'Search for something';
 const description = 'How to help users to search for something';
 const section = 'Patterns';
 const subsection = 'Help users to';
+
+const applySearchNarrow = require('../../../../assets/images/patterns/search-narrow.svg').default;
+const applySearchWide= require('../../../../assets/images/patterns/search-wide.svg').default;
 
 const Page: FC<PageProps> = ({ location }) => (
   <div className="govuk-grid-row">
@@ -22,39 +23,7 @@ const Page: FC<PageProps> = ({ location }) => (
     </Helmet>
 
     <div className="govuk-grid-column-one-quarter">
-      <span className="govuk-caption-m" style={{ marginBottom: "1em" }}>Help users to</span>
-      <NavigationMenu items={[
-
-        {
-          href: '/patterns/access-a-service',
-          text: 'Access a service'
-        },
-        {
-          href: '/patterns/add-multiple-things',
-          text: 'Add multiple things'
-        },
-        {
-          href: '/patterns/find-information-on-document',
-          text: 'Find information on a document'
-        },
-        {
-          href: '/patterns/get-more-details',
-          text: 'Get more details'
-        },
-        {
-          href: '/patterns/leave-a-service',
-          text: 'Leave a service'
-        },
-        {
-          href: '/patterns/stop-a-service-timing-out',
-          text: 'Stop a service timing out'
-        },
-        {
-          href: '/patterns/search-for-something',
-          text: 'Search for something'
-        }
-
-      ]} />
+      {menu}
     </div>
 
     <div className="govuk-grid-column-three-quarters">

--- a/apps/docs/src/common/pages/patterns/stop-a-service-timing-out.tsx
+++ b/apps/docs/src/common/pages/patterns/stop-a-service-timing-out.tsx
@@ -1,14 +1,15 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
-
-const applyModalWindow = require('../../../../assets/images/patterns/timeout.svg').default;
+import { A } from '@not-govuk/components';
+import { menu } from '../patterns';
 
 export const title = 'Stop a service timing out';
 const description = 'How to help users to stop a service from timing out';
 const section = 'Patterns';
 const subsection = 'Help users to';
+
+const applyModalWindow = require('../../../../assets/images/patterns/timeout.svg').default;
 
 const Page: FC<PageProps> = ({ location }) => (
 <div className="govuk-grid-row">
@@ -21,38 +22,7 @@ const Page: FC<PageProps> = ({ location }) => (
   </Helmet>
 
     <div className="govuk-grid-column-one-quarter">
-    <span className="govuk-caption-m" style={{marginBottom: "1em"}}>Help users to</span>
-      <NavigationMenu items={[
-
-        {
-          href: '/patterns/access-a-service',
-          text: 'Access a service'
-        },
-        {
-          href: '/patterns/add-multiple-things',
-          text: 'Add multiple things'
-        },
-        {
-          href: '/patterns/find-information-on-document',
-          text: 'Find information on a document'
-        },
-        {
-          href: '/patterns/get-more-details',
-          text: 'Get more details'
-        },
-        {
-          href: '/patterns/leave-a-service',
-          text: 'Leave a service'
-        },
-        {
-          href: '/patterns/stop-a-service-timing-out',
-          text: 'Stop a service timing out'
-        },
-        {
-          href: '/patterns/search-for-something',
-          text: 'Search for something'
-        }
-      ]} />
+      {menu}
     </div>
 
     <div className="govuk-grid-column-three-quarters">

--- a/apps/docs/src/common/pages/styles.tsx
+++ b/apps/docs/src/common/pages/styles.tsx
@@ -1,14 +1,33 @@
-import { FC, createElement as h } from 'react';
+import { FC, Fragment, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
 import { A, NavigationMenu } from '@not-govuk/components';
 
-const applyPassportImage = require('../../../assets/images/apply-passport.png').default;
-const ddatEventsImage = require('../../../assets/images/ddat-events.png').default;
-const policeImage = require('../../../assets/images/police.png').default;
+export const menu = (
+  <Fragment>
+    <NavigationMenu items={[
+      {
+        href: '/styles/colour',
+        text: 'Colour'
+      },
+      {
+        href: '/styles/images',
+        text: 'Images'
+      },
+      {
+        href: '/styles/typography',
+        text: 'Typography'
+      }
+    ]} />
+  </Fragment>
+);
 
 export const title = 'Styles';
 const description = 'Make your service look and feel like a Home Office service';
+
+const applyPassportImage = require('../../../assets/images/apply-passport.png').default;
+const ddatEventsImage = require('../../../assets/images/ddat-events.png').default;
+const policeImage = require('../../../assets/images/police.png').default;
 
 const Page: FC<PageProps> = ({ location }) => (
   <div className="govuk-grid-row">
@@ -20,20 +39,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={title} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-      <NavigationMenu items={[
-        {
-          href: '/styles/colour',
-          text: 'Colour'
-        },
-        {
-          href: '/styles/images',
-          text: 'Images'
-        },
-        {
-          href: '/styles/typography',
-          text: 'Typography'
-        }
-      ]} />
+      {menu}
     </div>
     <div className="govuk-grid-column-three-quarters">
       <h1>{title}</h1>

--- a/apps/docs/src/common/pages/styles/colour.tsx
+++ b/apps/docs/src/common/pages/styles/colour.tsx
@@ -1,7 +1,12 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../styles';
+
+export const title = 'Colour';
+const description = 'Always use the Home Office colour palette';
+const section = 'Styles';
 
 import '../../../../assets/colour.scss';
 
@@ -15,9 +20,6 @@ const colour = (colour: string, whiteText: boolean = false) => ({
   border: '1px solid #CBCBCB'
 });
 
-export const title = 'Colour';
-const description = 'Always use the Home Office colour palette';
-const section = 'Styles';
 
 const Page: FC<PageProps> = ({ location }) => (
   <div className="govuk-grid-row">
@@ -29,20 +31,7 @@ const Page: FC<PageProps> = ({ location }) => (
       <meta name="og:article:section" content={section} />
     </Helmet>
     <div className="govuk-grid-column-one-quarter">
-      <NavigationMenu items={[
-        {
-          href: '/styles/colour',
-          text: 'Colour'
-        },
-        {
-          href: '/styles/images',
-          text: 'Images'
-        },
-        {
-          href: '/styles/typography',
-          text: 'Typography'
-        }
-      ]} />
+      {menu}
     </div>
 
     <div className="govuk-grid-column-three-quarters">

--- a/apps/docs/src/common/pages/styles/images.tsx
+++ b/apps/docs/src/common/pages/styles/images.tsx
@@ -1,17 +1,18 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../styles';
+
+export const title = 'Images';
+const description = 'Only use images if there’s a real user need';
+const section = 'Styles';
 
 const applyImageInline = require('../../../../assets/images/patterns/image-guidance-inline.svg').default;
 const applyExample1 = require('../../../../assets/images/example-1.jpg').default;
 const applyExample2 = require('../../../../assets/images/example-2.jpg').default;
 const applyExample5 = require('../../../../assets/images/example-5.jpg').default;
 const applyExample6 = require('../../../../assets/images/example-6.jpg').default;
-
-export const title = 'Images';
-const description = 'Only use images if there’s a real user need';
-const section = 'Styles';
 
 const Page: FC<PageProps> = ({ location }) => (
 <div className="govuk-grid-row">
@@ -24,20 +25,7 @@ const Page: FC<PageProps> = ({ location }) => (
   </Helmet>
 
     <div className="govuk-grid-column-one-quarter">
-      <NavigationMenu items={[
-        {
-          href: '/styles/colour',
-          text: 'Colour'
-        },
-        {
-          href: '/styles/images',
-          text: 'Images'
-        },
-        {
-          href: '/styles/typography',
-          text: 'Typography'
-        }
-      ]} />
+      {menu}
     </div>
 
     <div className="govuk-grid-column-three-quarters">

--- a/apps/docs/src/common/pages/styles/typography.tsx
+++ b/apps/docs/src/common/pages/styles/typography.tsx
@@ -1,7 +1,8 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A, NavigationMenu } from '@not-govuk/components';
+import { A } from '@not-govuk/components';
+import { menu } from '../styles';
 
 export const title = 'Typography';
 const description = 'If your service is on the homeoffice.gov.uk subdomain you should use the Roboto font instead of the GDS Transport font';
@@ -18,20 +19,7 @@ const Page: FC<PageProps> = ({ location }) => (
     </Helmet>
 
     <div className="govuk-grid-column-one-quarter">
-      <NavigationMenu items={[
-        {
-          href: '/styles/colour',
-          text: 'Colour'
-        },
-        {
-          href: '/styles/images',
-          text: 'Images'
-        },
-        {
-          href: '/styles/typography',
-          text: 'Typography'
-        }
-      ]} />
+      {menu}
     </div>
 
     <div className="govuk-grid-column-three-quarters">


### PR DESCRIPTION
Reduces code duplication by defining the side navigation menus in the
main page and simply importing it into the subpages.

This should make things easier to manage and help to prevent
inconsistent menus.