### PR TITLE
Fix mistakes in contribute guidance

### DIFF
--- a/apps/docs/src/common/pages/contribute.tsx
+++ b/apps/docs/src/common/pages/contribute.tsx
@@ -8,7 +8,7 @@ export const menu = (
     <NavigationMenu items={[
           {
             href: '/contribute/discuss-on-github',
-            text: 'Discuss on github'
+            text: 'Discuss on GitHub'
           },
           {
             href: '/contribute/design-system-working-group',
@@ -41,14 +41,14 @@ const Page: FC<PageProps> = ({ location }) => (
       <li>ask questions about a style, component or pattern</li>
       <li>answer questions from others</li>
       <li>share examples or demos of a component or pattern</li>
-      <li>share research relating to a style, compontent or pattern</li>
+      <li>share research relating to a style, component or pattern</li>
     </ul>
     <h2>Make a suggestion</h2>
     <h3>1. Check if there's already a discussion</h3>
     <p><a href="https://github.com/UKHomeOffice/design-system/discussions">Check if there are any open discussions</a> about your suggestion on the design system github.</p>
     <h3>2. Create a new discussion</h3>
     <p>If there is not a discussion, <a href="https://github.com/UKHomeOffice/design-system/discussions/new">start a new discussion</a> on github. Select ‘ideas’ from the ‘select category’ list when starting to create the discussion.</p>
-    <p>For help, use our <a href="/contribute/discuss-on-github">github guide</a> or ask the <a href="/contribute/design-system-working-group">working group</a>.</p>
+    <p>For help, use our <a href="/contribute/discuss-on-github">GitHub guide</a> or ask the <a href="/contribute/design-system-working-group">working group</a>.</p>
     <p>When discussing a proposal for a new component, try to explain why it should be included in our design system. If you can, include screenshots and research findings.</p>
     <h3>3. Share the discussion</h3>
     <p>Let the user-centred design and accessibility community know that you have posted a new discussion and ask their comments.</p>

--- a/apps/docs/src/common/pages/contribute.tsx
+++ b/apps/docs/src/common/pages/contribute.tsx
@@ -45,9 +45,9 @@ const Page: FC<PageProps> = ({ location }) => (
     </ul>
     <h2>Make a suggestion</h2>
     <h3>1. Check if there's already a discussion</h3>
-    <p><a href="https://github.com/UKHomeOffice/design-system/discussions">Check if there are any open discussions</a> about your suggestion on the design system github.</p>
+    <p><a href="https://github.com/UKHomeOffice/design-system/discussions">Check if there are any open discussions</a> about your suggestion on the design system GitHub.</p>
     <h3>2. Create a new discussion</h3>
-    <p>If there is not a discussion, <a href="https://github.com/UKHomeOffice/design-system/discussions/new">start a new discussion</a> on github. Select ‘ideas’ from the ‘select category’ list when starting to create the discussion.</p>
+    <p>If there is not a discussion, <a href="https://github.com/UKHomeOffice/design-system/discussions/new">start a new discussion</a> on GitHub. Select ‘ideas’ from the ‘select category’ list when starting to create the discussion.</p>
     <p>For help, use our <a href="/contribute/discuss-on-github">GitHub guide</a> or ask the <a href="/contribute/design-system-working-group">working group</a>.</p>
     <p>When discussing a proposal for a new component, try to explain why it should be included in our design system. If you can, include screenshots and research findings.</p>
     <h3>3. Share the discussion</h3>

--- a/apps/docs/src/common/pages/contribute/discuss-on-github.tsx
+++ b/apps/docs/src/common/pages/contribute/discuss-on-github.tsx
@@ -27,7 +27,7 @@ const Page: FC<PageProps> = ({ location }) => (
       </h1>
       <p>Our <a href="https://github.com/UKHomeOffice/design-system/discussions">GitHub repository discussions</a> is where our designs are discussed and problems explored.</p>
       <h2>Create an account</h2>
-      <p><a href="https://github.com/signup?return_to=https%3A%2F%2Fgithub.com%2FUKHomeOffice%2Fdesign-system%2Fdiscussions&source=login">Create a github account</a> with any email address, including your Home Office email addresses.</p>
+      <p><a href="https://github.com/signup?return_to=https%3A%2F%2Fgithub.com%2FUKHomeOffice%2Fdesign-system%2Fdiscussions&source=login">Create a GitHub account</a> with any email address, including your Home Office email addresses.</p>
       <h2>Join a discussion</h2>
       <p>If there's an existing discussion, you can:</p>
       <ul>

--- a/apps/docs/src/common/pages/contribute/discuss-on-github.tsx
+++ b/apps/docs/src/common/pages/contribute/discuss-on-github.tsx
@@ -4,7 +4,7 @@ import { PageProps } from '@not-govuk/app-composer';
 import { A } from '@not-govuk/components';
 import { menu } from '../contribute';
 
-export const title = 'Discuss on github';
+export const title = 'Discuss on GitHub';
 const description = 'Contribute your ideas, thoughts and evidence';
 const section = 'Contribute';
 
@@ -25,7 +25,7 @@ const Page: FC<PageProps> = ({ location }) => (
         <span className="caption">{section}</span>
         {title}
       </h1>
-      <p>Our <a href="https://github.com/UKHomeOffice/design-system/discussions">github repository discussions</a> is where our designs are discussed and problems explored.</p>
+      <p>Our <a href="https://github.com/UKHomeOffice/design-system/discussions">GitHub repository discussions</a> is where our designs are discussed and problems explored.</p>
       <h2>Create an account</h2>
       <p><a href="https://github.com/signup?return_to=https%3A%2F%2Fgithub.com%2FUKHomeOffice%2Fdesign-system%2Fdiscussions&source=login">Create a github account</a> with any email address, including your Home Office email addresses.</p>
       <h2>Join a discussion</h2>
@@ -34,7 +34,7 @@ const Page: FC<PageProps> = ({ location }) => (
         <li>ask questions about a style, component or pattern</li>
         <li>answer questions from others</li>
         <li>share examples or demos of a component or pattern</li>
-        <li>share research relating to a style, compontent or pattern</li>
+        <li>share research relating to a style, component or pattern</li>
       </ul>
       <h2>Create a new discussion</h2>
       <p>Your new discussion can be as simple as a thought you've had, or more well-formed research findings.</p>

--- a/apps/docs/src/common/pages/get-started.tsx
+++ b/apps/docs/src/common/pages/get-started.tsx
@@ -63,7 +63,7 @@ const Page: FC<PageProps> = ({ location }) => (
           </ul>
 
       <h2>Contribute</h2>
-        <p>Get involved with <A href="https://github.com/UKHomeOffice/design-system/discussions">github discussions</A> about our styles, components and patterns.</p>
+        <p>Get involved with <A href="https://github.com/UKHomeOffice/design-system/discussions">GitHub discussions</A> about our styles, components and patterns.</p>
     </div>
   </div>
 );

--- a/apps/docs/src/common/pages/index.tsx
+++ b/apps/docs/src/common/pages/index.tsx
@@ -27,7 +27,7 @@ const Page: FC<PageProps> = props => (
           <ul className="govuk-!-font-size-16">
             <li>Added <A href="/accessibility/gestures-and-motion">gestures and motion accessibility guidance</A></li>
             <li>Updated <A href="/contribute">how to contribute</A> to the design system</li>
-            <li>Using <A href="https://github.com/UKHomeOffice/design-system/discussions">discussions</A> on github</li>
+            <li>Using <A href="https://github.com/UKHomeOffice/design-system/discussions">discussions</A> on GitHub</li>
           </ul>
         </aside>
       </div>


### PR DESCRIPTION
Changes 'github' to 'GitHub' for consistency.
Fixes 'compontent' to 'component'.