### PR TITLE
Time: Force lowercase to handle missing locale

### DIFF
--- a/components/time/src/utils.ts
+++ b/components/time/src/utils.ts
@@ -11,5 +11,6 @@ export const formatTime = (
 		    minute: '2-digit'
 		  })
 		  .replace(' ','')
+      .toLowerCase()
 	);
 };


### PR DESCRIPTION
We don't always have the en_GB locale available and end up with en_US.
This results in AM and PM being capitalised. We should force lower-case
to handle this scenario.