### PR TITLE
Flip wrap props to noWrap

### DIFF
--- a/components/date-display/spec/DateDisplay.stories.mdx
+++ b/components/date-display/spec/DateDisplay.stories.mdx
@@ -44,6 +44,9 @@ Follow the [GOV.UK date guidance](https://www.gov.uk/guidance/style-guide/a-to-z
 
 <Preview>
   <Story name="No wrap">
-    <DateDisplay date="2022-07-20" wrap={false} />
+    <DateDisplay
+      date="2022-07-20"
+      noWrap
+    />
   </Story>
 </Preview>

--- a/components/date-display/spec/DateDisplay.stories.mdx
+++ b/components/date-display/spec/DateDisplay.stories.mdx
@@ -39,14 +39,3 @@ Follow the [GOV.UK date guidance](https://www.gov.uk/guidance/style-guide/a-to-z
     <DateDisplay date="2022-07-20" />
   </Story>
 </Preview>
-
-### No wrap
-
-<Preview>
-  <Story name="No wrap">
-    <DateDisplay
-      date="2022-07-20"
-      noWrap
-    />
-  </Story>
-</Preview>

--- a/components/date-display/spec/DateDisplay.ts
+++ b/components/date-display/spec/DateDisplay.ts
@@ -19,7 +19,7 @@ describe('DateDisplay', () => {
   describe('when given all valid props', () => {
     const props = {
       ...minimalProps,
-      wrap:false
+      noWrap: true
     };
     const component = mount(h(DateDisplay, props));
 

--- a/components/date-display/src/DateDisplay.tsx
+++ b/components/date-display/src/DateDisplay.tsx
@@ -6,9 +6,8 @@ import '../assets/DateDisplay.scss';
 export type DateDisplayProps = StandardProps & {
   /** The date in ISO format */
   date: string
-  /** Whether to wrap the date in a time element */
-  wrap?: boolean
- 
+  /** Whether to not wrap the date in a time element */
+  noWrap?: boolean
 };
 
 export const DateDisplay: FC<DateDisplayProps> = ({
@@ -17,21 +16,21 @@ export const DateDisplay: FC<DateDisplayProps> = ({
   classModifiers,
   className,
   date: _date,
-  wrap = true,
+  noWrap = false,
   ...attrs
 }) => {
   const classes = classBuilder('hods-date-display', classBlock, classModifiers, className);
   const date = new Date(_date);
   const formattedDate = date.toLocaleString("en-GB", {year: "numeric", month: "long", day: "numeric"});
 
-  return wrap ? (
-    <time {...attrs} className={classes()} dateTime={_date}>
-      {formattedDate}
-    </time>
-  ) : (
+  return noWrap ? (
     <Fragment>
       {formattedDate}
     </Fragment>
+  ) : (
+    <time {...attrs} className={classes()} dateTime={_date}>
+      {formattedDate}
+    </time>
   );
 };
 

--- a/components/date-time/src/DateTime.tsx
+++ b/components/date-time/src/DateTime.tsx
@@ -35,11 +35,11 @@ export const DateTime: FC<DateTimeProps> = ({
 		<time {...attrs} className={classes()} dateTime={dateTime}>
 		{ precedence === "time" ? (
 		<Fragment>
-		<Time time={dateTime} wrap={false} clockType={clockType} /> on <DateDisplay date={dateTime} wrap={false} />
+		<Time time={dateTime} clockType={clockType} noWrap /> on <DateDisplay date={dateTime} noWrap />
 		</Fragment>
 		):(
 		<Fragment>
-		<DateDisplay date={dateTime} wrap={false} /> at <Time time={dateTime} wrap={false} clockType={clockType} />
+		<DateDisplay date={dateTime} noWrap /> at <Time time={dateTime} clockType={clockType} noWrap />
 		</Fragment>
 		)}
 		</time>

--- a/components/time/spec/Time.stories.mdx
+++ b/components/time/spec/Time.stories.mdx
@@ -53,17 +53,3 @@ Display the time in the 24 hour clock.
 	/>
   </Story>
 </Preview>
-
-### No wrap
-
-Display the time without a time element.
-
-<Preview>
-  <Story name="No wrap">
-	<Time
-	  time="2022-07-21T22:37:34.570Z"
-	  noWrap
-	/>
-  </Story>
-  
-</Preview>

--- a/components/time/spec/Time.stories.mdx
+++ b/components/time/spec/Time.stories.mdx
@@ -62,7 +62,7 @@ Display the time without a time element.
   <Story name="No wrap">
 	<Time
 	  time="2022-07-21T22:37:34.570Z"
-	  wrap={false}
+	  noWrap
 	/>
   </Story>
   

--- a/components/time/spec/Time.ts
+++ b/components/time/spec/Time.ts
@@ -48,7 +48,7 @@ describe('Time', () => {
 describe('when given wrap false prop', () => {
     const props = {
       ...minimalProps,
-      wrap:false
+      noWrap: true
     };
     const component = mount(h(Time, props));
 

--- a/components/time/src/Time.tsx
+++ b/components/time/src/Time.tsx
@@ -7,8 +7,8 @@ import '../assets/Time.scss';
 export type TimeProps = StandardProps & {
   /** Displays time as a 12 or 24 hour clock */
   clockType?: 12 | 24
-  /** Whether to wrap the time in a time element */
-  wrap?: boolean
+  /** Whether to not wrap the time in a time element */
+  noWrap?: boolean
     /** The time in ISO format */
   time: string
 };
@@ -20,7 +20,7 @@ export const Time: FC<TimeProps> = ({
   	className,
   	clockType = 12,
   	time,
-  	wrap = true,
+    noWrap = false,
   	...attrs
 }) => {
   const classes = classBuilder('hods-time', classBlock, classModifiers, className);
@@ -30,14 +30,14 @@ export const Time: FC<TimeProps> = ({
 	  clockType
   );
   
-  return wrap ? (
-    <time {...attrs} className={classes()} dateTime={time}>
-      {formattedTime}
-    </time>
-  ) : (
+  return noWrap ? (
     <Fragment>
       {formattedTime}
     </Fragment>
+  ) : (
+    <time {...attrs} className={classes()} dateTime={time}>
+      {formattedTime}
+    </time>
   );
   
 };


### PR DESCRIPTION
Reverses the meaning of the `wrap` props on the new DateDisplay and Time components. This is because React has some nice syntax for handling flags.

Also removes public documentation for these props as they are mainly of use to ourselves in the DateTime component.