### PR TITLE
Pagination: Refactor and simplify interface

### DIFF
--- a/components/pagination/assets/Pagination.scss
+++ b/components/pagination/assets/Pagination.scss
@@ -1,44 +1,48 @@
 @import "@hods/sass-base";
 
 .hods-pagination {
-
-  &__summary {
-    @include govuk-font(16);
-    @include govuk-responsive-padding(2, "bottom");
-    @include govuk-responsive-padding(2, "top");;
-    float: right;
-  }
-
-  &__item {
-    display: inline-block;
-  }
-
-  &__link {
-    @include govuk-font(16);
-    @include govuk-responsive-padding(1, "bottom");
-    @include govuk-responsive-padding(1, "top");
-    @include govuk-responsive-padding(2, "left");
-    @include govuk-responsive-padding(2, "right");
-    text-decoration: none;
-
-    &:hover, &:focus {
+  &__navigation {
+    &__summary {
       @include govuk-font(16);
-      outline: 3px solid govuk-colour("yellow");
+      @include govuk-responsive-padding(2, "bottom");
+      @include govuk-responsive-padding(2, "top");;
+      float: right;
     }
 
-    &--current {
+    &__item {
+      display: inline-block;
+    }
+
+    &__link {
       @include govuk-font(16);
       @include govuk-responsive-padding(1, "bottom");
       @include govuk-responsive-padding(1, "top");
       @include govuk-responsive-padding(2, "left");
       @include govuk-responsive-padding(2, "right");
-      font-weight: bold;
-      border: none;
-      pointer-events: none;
-      cursor: default;
+      text-decoration: none;
 
-      &:link, &:visited {
-        color: black
+      &:hover, &:focus {
+        @include govuk-font(16);
+        outline: 3px solid govuk-colour("yellow");
+      }
+
+      &--current {
+        @include govuk-font(16);
+        @include govuk-responsive-padding(1, "bottom");
+        @include govuk-responsive-padding(1, "top");
+        @include govuk-responsive-padding(2, "left");
+        @include govuk-responsive-padding(2, "right");
+        font-weight: bold;
+        border: none;
+        pointer-events: none;
+        cursor: default;
+
+        &:link,
+        &:visited,
+        &.govuk-link:link,
+        &.govuk-link:visited {
+          color: black
+        }
       }
     }
   }

--- a/components/pagination/package.json
+++ b/components/pagination/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@hods/sass-base": "workspace:^0.3.5",
     "@not-govuk/component-helpers": "^0.5.7",
+    "@not-govuk/link": "^0.5.7",
     "@not-govuk/route-utils": "^0.5.7"
   },
   "peerDependencies": {

--- a/components/pagination/spec/Navigation.ts
+++ b/components/pagination/spec/Navigation.ts
@@ -1,0 +1,50 @@
+import { createElement as h } from 'react';
+import { mount } from '@not-govuk/component-test-helpers';
+import Navigation from '../src/Navigation';
+
+describe('Navigation', () => {
+  const minimalProps = {
+    results: 30,
+    resultsPerPage: 3,
+    page: 3,
+  };
+
+  describe('when given minimal valid props', () => {
+    const navigation = mount(h(Navigation, minimalProps));
+
+    const summary = navigation.find('.hods-pagination-navigation__summary');
+    const current = navigation.find('A[aria-current="true"]').first();
+
+    it('shows the current page', () => expect(current.length).toEqual(1));
+    it('displays the correct page', () => expect(current.text()).toEqual('3'));
+    it('displays a summary', () => expect(summary.text()).toEqual('Showing 7 - 9 of 30 results'));
+    it('displays a link to the next page', () => expect(navigation.text()).toContain('Next'));
+    it('displays a link to previous page', () => expect(navigation.text()).toContain('Previous'));
+  });
+
+  describe('when given minimal valid props set to the first page', () => {
+    const navigation = mount(h(Navigation, { ...minimalProps, page: 1 }));
+
+    const summary = navigation.find('.hods-pagination-navigation__summary');
+    const current = navigation.find('A[aria-current="true"]').first();
+
+    it('shows the current page', () => expect(current.length).toEqual(1));
+    it('displays the correct page', () => expect(current.text()).toEqual('1'));
+    it('displays a summary', () => expect(summary.text()).toEqual('Showing 1 - 3 of 30 results'));
+    it('displays a link to the next page', () => expect(navigation.text()).toContain('Next'));
+    it('does NOT display a link to previous page', () => expect(navigation.text()).not.toContain('Previous'));
+  });
+
+  describe('when given minimal valid props set to the last page', () => {
+    const navigation = mount(h(Navigation, { ...minimalProps, page: 10 }));
+
+    const summary = navigation.find('.hods-pagination-navigation__summary');
+    const current = navigation.find('A[aria-current="true"]').first();
+
+    it('shows the current page', () => expect(current.length).toEqual(1));
+    it('displays the correct page', () => expect(current.text()).toEqual('10'));
+    it('displays a summary', () => expect(summary.text()).toEqual('Showing 28 - 30 of 30 results'));
+    it('does NOT display a link to the next page', () => expect(navigation.text()).not.toContain('Next'));
+    it('displays a link to previous page', () => expect(navigation.text()).toContain('Previous'));
+  });
+});

--- a/components/pagination/spec/Navigation.ts
+++ b/components/pagination/spec/Navigation.ts
@@ -1,5 +1,5 @@
 import { createElement as h } from 'react';
-import { mount } from '@not-govuk/component-test-helpers';
+import { render, screen } from '@not-govuk/component-test-helpers';
 import Navigation from '../src/Navigation';
 
 describe('Navigation', () => {
@@ -8,43 +8,41 @@ describe('Navigation', () => {
     resultsPerPage: 3,
     page: 3,
   };
+  const current = () => screen.getByRole('link', { current: true });
 
   describe('when given minimal valid props', () => {
-    const navigation = mount(h(Navigation, minimalProps));
+    beforeEach(() => {
+      render(h(Navigation, minimalProps));
+    });
 
-    const summary = navigation.find('.hods-pagination-navigation__summary');
-    const current = navigation.find('A[aria-current="true"]').first();
-
-    it('shows the current page', () => expect(current.length).toEqual(1));
-    it('displays the correct page', () => expect(current.text()).toEqual('3'));
-    it('displays a summary', () => expect(summary.text()).toEqual('Showing 7 - 9 of 30 results'));
-    it('displays a link to the next page', () => expect(navigation.text()).toContain('Next'));
-    it('displays a link to previous page', () => expect(navigation.text()).toContain('Previous'));
+    it('shows the current page', () => expect(current()).toBeTruthy());
+    it('displays the correct page', () => expect(current().textContent).toBe('3'));
+    it('displays a summary', () => expect(screen.getByText('Showing 7 - 9 of 30 results')).toBeTruthy());
+    it('displays a link to the next page', () => expect(screen.getByLabelText('Next page', { exact: false }).textContent).toContain('Next'));
+    it('displays a link to the previous page', () => expect(screen.getByLabelText('Previous page', { exact: false }).textContent).toContain('Previous'));
   });
 
   describe('when given minimal valid props set to the first page', () => {
-    const navigation = mount(h(Navigation, { ...minimalProps, page: 1 }));
+    beforeEach(() => {
+      render(h(Navigation, { ...minimalProps, page: 1 }));
+    });
 
-    const summary = navigation.find('.hods-pagination-navigation__summary');
-    const current = navigation.find('A[aria-current="true"]').first();
-
-    it('shows the current page', () => expect(current.length).toEqual(1));
-    it('displays the correct page', () => expect(current.text()).toEqual('1'));
-    it('displays a summary', () => expect(summary.text()).toEqual('Showing 1 - 3 of 30 results'));
-    it('displays a link to the next page', () => expect(navigation.text()).toContain('Next'));
-    it('does NOT display a link to previous page', () => expect(navigation.text()).not.toContain('Previous'));
+    it('shows the current page', () => expect(current()).toBeTruthy());
+    it('displays the correct page', () => expect(current().textContent).toBe('1'));
+    it('displays a summary', () => expect(screen.getByText('Showing 1 - 3 of 30 results')).toBeTruthy());
+    it('displays a link to the next page', () => expect(screen.getByLabelText('Next page', { exact: false }).textContent).toContain('Next'));
+    it('does NOT display a link to the previous page', () => expect(screen.queryByLabelText('Previous page', { exact: false })).toBeFalsy());
   });
 
   describe('when given minimal valid props set to the last page', () => {
-    const navigation = mount(h(Navigation, { ...minimalProps, page: 10 }));
+    beforeEach(() => {
+      render(h(Navigation, { ...minimalProps, page: 10 }));
+    });
 
-    const summary = navigation.find('.hods-pagination-navigation__summary');
-    const current = navigation.find('A[aria-current="true"]').first();
-
-    it('shows the current page', () => expect(current.length).toEqual(1));
-    it('displays the correct page', () => expect(current.text()).toEqual('10'));
-    it('displays a summary', () => expect(summary.text()).toEqual('Showing 28 - 30 of 30 results'));
-    it('does NOT display a link to the next page', () => expect(navigation.text()).not.toContain('Next'));
-    it('displays a link to previous page', () => expect(navigation.text()).toContain('Previous'));
+    it('shows the current page', () => expect(current()).toBeTruthy());
+    it('displays the correct page', () => expect(current().textContent).toBe('10'));
+    it('displays a summary', () => expect(screen.getByText('Showing 28 - 30 of 30 results')).toBeTruthy());
+    it('does NOT display a link to the next page', () => expect(screen.queryByLabelText('Next page', { exact: false })).toBeFalsy());
+    it('displays a link to the previous page', () => expect(screen.getByLabelText('Previous page', { exact: false }).textContent).toContain('Previous'));
   });
 });

--- a/components/pagination/spec/Pagination.stories.mdx
+++ b/components/pagination/spec/Pagination.stories.mdx
@@ -152,7 +152,7 @@ Display a different number of results per page.
 
 ### Custom query parameter
 
-Control the GET / query parameter used to set the active page with the `sizeParameter` prop.
+Control the GET / query parameter used to set the active page with the `pageParameter` prop.
 
 <Preview>
   <Story name="Parameter">

--- a/components/pagination/spec/Pagination.stories.mdx
+++ b/components/pagination/spec/Pagination.stories.mdx
@@ -19,11 +19,38 @@ A component for navigating a long list of results.
 
 <Preview withToolbar>
   <Story name="Pagination">
-    <Pagination
-      results="249"
-      resultsPerPage="25"
-      page="3"
-    />
+    <Pagination>
+      <div>1</div>
+      <div>2</div>
+      <div>3</div>
+      <div>4</div>
+      <div>5</div>
+      <div>6</div>
+      <div>7</div>
+      <div>8</div>
+      <div>9</div>
+      <div>10</div>
+      <div>11</div>
+      <div>12</div>
+      <div>13</div>
+      <div>14</div>
+      <div>15</div>
+      <div>16</div>
+      <div>17</div>
+      <div>18</div>
+      <div>19</div>
+      <div>20</div>
+      <div>21</div>
+      <div>22</div>
+      <div>23</div>
+      <div>24</div>
+      <div>25</div>
+      <div>26</div>
+      <div>27</div>
+      <div>28</div>
+      <div>29</div>
+      <div>30</div>
+    </Pagination>
   </Story>
 </Preview>
 
@@ -46,124 +73,120 @@ the better the search results.
 
 <Preview>
   <Story name="Standard">
-    <Pagination
-      results="20"
-      resultsPerPage="5"
-      page="3"
-    >
-      {[
-        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-      ].map((c) => {
-        return <div id={`${c.toString()}`}>{c}</div>;
-      })}
+    <Pagination>
+      <div>1</div>
+      <div>2</div>
+      <div>3</div>
+      <div>4</div>
+      <div>5</div>
+      <div>6</div>
+      <div>7</div>
+      <div>8</div>
+      <div>9</div>
+      <div>10</div>
+      <div>11</div>
+      <div>12</div>
+      <div>13</div>
+      <div>14</div>
+      <div>15</div>
+      <div>16</div>
+      <div>17</div>
+      <div>18</div>
+      <div>19</div>
+      <div>20</div>
+      <div>21</div>
+      <div>22</div>
+      <div>23</div>
+      <div>24</div>
+      <div>25</div>
+      <div>26</div>
+      <div>27</div>
+      <div>28</div>
+      <div>29</div>
+      <div>30</div>
     </Pagination>
   </Story>
 </Preview>
-
-### Start of pagination
-
-Display the first page of results.
-
-<Preview>
-  <Story name="Start">
-    <Pagination
-      results="20"
-      resultsPerPage="5"
-      page="1"
-    >
-      {[
-        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-      ].map((c) => {
-        return <div id={`${c.toString()}`}>{c}</div>;
-      })}
-    </Pagination>
-  </Story>
-</Preview>
-
-
-### Middle of pagination
-
-Show the middle of the results.
-
-<Preview>
-  <Story name="Middle">
-    <Pagination
-      results="30"
-      resultsPerPage="5"
-      page="3"
-    >
-      {[
-        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-        21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
-      ].map((c) => {
-        return <div id={`${c.toString()}`}>{c}</div>;
-      })}
-    </Pagination>
-  </Story>
-</Preview>
-
-
-### End of pagination
-
-Display the last page of results.
-
-<Preview>
-  <Story name="End">
-    <Pagination
-      results="30"
-      resultsPerPage="5"
-      page="6"
-    >
-      {[
-        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-        21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
-      ].map((c) => {
-        return <div id={`${c.toString()}`}>{c}</div>;
-      })}
-    </Pagination>
-  </Story>
-</Preview>
-
-
-### Near end
-
-Display the second to last page of results.
-
-<Preview>
-  <Story name="NrEnd">
-    <Pagination
-      results="30"
-      resultsPerPage="5"
-      page="5"
-    >
-      {[
-        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-        21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
-      ].map((c) => {
-        return <div id={`${c.toString()}`}>{c}</div>;
-      })}
-    </Pagination>
-  </Story>
-</Preview>
-
 
 ### Results per page
 
 Display a different number of results per page.
 
 <Preview>
-  <Story name="Odd Number">
-    <Pagination
-      results="30"
-      resultsPerPage="7"
-      page="5"
-    >
-      {[
-        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-        21, 22, 23, 24, 25, 26, 27, 28, 29, 30,
-      ].map((c) => {
-        return <div id={`${c.toString()}`}>{c}</div>;
-      })}
+  <Story name="Size">
+    <Pagination size={5}>
+      <div>1</div>
+      <div>2</div>
+      <div>3</div>
+      <div>4</div>
+      <div>5</div>
+      <div>6</div>
+      <div>7</div>
+      <div>8</div>
+      <div>9</div>
+      <div>10</div>
+      <div>11</div>
+      <div>12</div>
+      <div>13</div>
+      <div>14</div>
+      <div>15</div>
+      <div>16</div>
+      <div>17</div>
+      <div>18</div>
+      <div>19</div>
+      <div>20</div>
+      <div>21</div>
+      <div>22</div>
+      <div>23</div>
+      <div>24</div>
+      <div>25</div>
+      <div>26</div>
+      <div>27</div>
+      <div>28</div>
+      <div>29</div>
+      <div>30</div>
+    </Pagination>
+  </Story>
+</Preview>
+
+
+### Custom query parameter
+
+Control the GET / query parameter used to set the active page with the `sizeParameter` prop.
+
+<Preview>
+  <Story name="Parameter">
+    <Pagination pageParameter="p">
+      <div>1</div>
+      <div>2</div>
+      <div>3</div>
+      <div>4</div>
+      <div>5</div>
+      <div>6</div>
+      <div>7</div>
+      <div>8</div>
+      <div>9</div>
+      <div>10</div>
+      <div>11</div>
+      <div>12</div>
+      <div>13</div>
+      <div>14</div>
+      <div>15</div>
+      <div>16</div>
+      <div>17</div>
+      <div>18</div>
+      <div>19</div>
+      <div>20</div>
+      <div>21</div>
+      <div>22</div>
+      <div>23</div>
+      <div>24</div>
+      <div>25</div>
+      <div>26</div>
+      <div>27</div>
+      <div>28</div>
+      <div>29</div>
+      <div>30</div>
     </Pagination>
   </Story>
 </Preview>

--- a/components/pagination/spec/Pagination.ts
+++ b/components/pagination/spec/Pagination.ts
@@ -1,6 +1,6 @@
 import { createElement as h } from 'react';
 import { jest } from '@jest/globals';
-import { mount } from '@not-govuk/component-test-helpers';
+import { render, screen } from '@not-govuk/component-test-helpers';
 import Pagination from '../src/Pagination';
 
 describe('Pagination', () => {
@@ -15,24 +15,21 @@ describe('Pagination', () => {
       `Item #${i + 1}`
     )
   );
+  const current = () => screen.getByRole('link', { current: true });
 
   describe('when given minimal valid props', () => {
-    const pagination = mount(h(Pagination, minimalProps, children));
+    beforeEach(() => {
+      render(h(Pagination, minimalProps, children));
+    });
 
-    const content = pagination.find('.hods-pagination__content');
-    const navigation = pagination.find('.hods-pagination__navigation');
-
-    const summary = navigation.find('.hods-pagination__navigation__summary');
-    const current = navigation.find('A[aria-current="true"]').first();
-
-    it('shows the current page', () => expect(current.length).toEqual(1));
-    it('displays the first page', () => expect(current.text()).toEqual('1'));
-    it('displays the first element', () => expect(content.text()).toContain('Item #1'));
-    it('does NOT display the 11th element', () => expect(content.text()).not.toContain('Item #11'));
-    it('does NOT display the last element', () => expect(content.text()).not.toContain('Item #30'));
-    it('displays a summary', () => expect(summary.text()).toEqual('Showing 1 - 10 of 30 results'));
-    it('displays a link to the next page', () => expect(navigation.text()).toContain('Next'));
-    it('does NOT display a link to previous page', () => expect(navigation.text()).not.toContain('Previous'));
+    it('shows the current page', () => expect(current()).toBeTruthy());
+    it('displays the first page', () => expect(current().textContent).toBe('1'));
+    it('displays the first element', () => expect(screen.getByText('Item #1')).toBeTruthy());
+    it('does NOT display the 11th element', () => expect(screen.queryByText('Item #11')).toBeFalsy());
+    it('does NOT display the last element', () => expect(screen.queryByText('Item #30')).toBeFalsy());
+    it('displays a summary', () => expect(screen.getByText('Showing 1 - 10 of 30 results')).toBeTruthy());
+    it('displays a link to the next page', () => expect(screen.getByLabelText('Next page', { exact: false }).textContent).toContain('Next'));
+    it('does NOT display a link to the previous page', () => expect(screen.queryByLabelText('Previous page', { exact: false })).toBeFalsy());
 
     describe.skip('when \'Next\' is clicked', () => {
     });

--- a/components/pagination/spec/Pagination.ts
+++ b/components/pagination/spec/Pagination.ts
@@ -4,197 +4,37 @@ import { mount } from '@not-govuk/component-test-helpers';
 import Pagination from '../src/Pagination';
 
 describe('Pagination', () => {
-  describe.only('when given valid props and valid url location data', () => {
-    const pagination = mount(
-      h(Pagination, {
-        results: 249,
-        resultsPerPage: 25,
-        page: 3,
-      })
-    );
-
-    let current;
-    beforeAll(() => {
-      expect(
-        (current = pagination.find('.hods-pagination__link--current'))
-      ).toHaveLength(1);
-    });
-
-    it('is on the correct page', () => {
-      expect(current.text()).toEqual('3');
-    });
-
-    it('should not have a link', () => {
-      expect(current.html()).toContain('href=""');
-    });
-
-    const summary = pagination.find('.hods-pagination__summary').text();
-
-    it('displays the correct value for results from', () => {
-      expect(summary.slice(8, 10)).toEqual('51');
-    });
-
-    it('displays the correct value for results to', () => {
-      expect(summary.slice(13, 15)).toEqual('75');
-    });
-
-    it('displays the correct value for total results', () => {
-      expect(summary.slice(19, 22)).toEqual('249');
-    });
-
-    const ul = pagination.find('.hods-pagination__list-items');
-    const prev = pagination.find('#prevButton');
-    const next = pagination.find('#nextButton');
-
-    it('displays the previous link in the correct place', () => {
-      expect(ul.childAt(0)).toEqual(prev);
-    });
-
-    it('displays the next link in the correct place', () => {
-      expect(ul.childAt(6)).toEqual(next);
-    });
-
-    const content = [
-      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
-    ];
-    const items = content.map((c, i) => h(
-      'div', {
-        key: i,
-        id: c.toString()
+  const minimalProps = {
+  };
+  const children = Array.from(Array(30)).map(
+    (_, i) => h(
+      'div',
+      {
+        key: i
       },
-      c.toString()
-    ));
-    const props = {
-      results: content.length,
-      resultsPerPage: 5,
-      page: 1,
-      children: items
-    };
-
-    it('paginates content using url parameters', () => {
-      const wrapper = mount(h(Pagination, props));
-
-      expect(
-        wrapper.find('.hods-pagination__content').children().length
-      ).toEqual(5);
-      expect(wrapper.find('[id="1"]').exists()).toBeTruthy();
-      expect(wrapper.find('[id="2"]').exists()).toBeTruthy();
-      expect(wrapper.find('[id="3"]').exists()).toBeTruthy();
-      expect(wrapper.find('[id="4"]').exists()).toBeTruthy();
-      expect(wrapper.find('[id="5"]').exists()).toBeTruthy();
-      expect(wrapper.find('[id="6"]').exists()).toBeFalsy();
-      expect(wrapper.find('[id="7"]').exists()).toBeFalsy();
-      expect(wrapper.find('[id="8"]').exists()).toBeFalsy();
-      expect(wrapper.find('[id="9"]').exists()).toBeFalsy();
-      expect(wrapper.find('[id="10"]').exists()).toBeFalsy();
-      expect(wrapper.find('[id="11"]').exists()).toBeFalsy();
-      expect(wrapper.find('[id="12"]').exists()).toBeFalsy();
-      expect(wrapper.find('[id="13"]').exists()).toBeFalsy();
-      expect(wrapper.find('[id="14"]').exists()).toBeFalsy();
-      expect(wrapper.find('[id="15"]').exists()).toBeFalsy();
-      expect(wrapper.find('[id="16"]').exists()).toBeFalsy();
-      expect(wrapper.find('[id="17"]').exists()).toBeFalsy();
-      expect(wrapper.find('[id="18"]').exists()).toBeFalsy();
-      expect(wrapper.find('[id="19"]').exists()).toBeFalsy();
-      expect(wrapper.find('[id="20"]').exists()).toBeFalsy();
-    });
-
-    it.skip('moves to the next page when \'next\' is clicked', () => {
-      const wrapper = mount(h(Pagination, {
-        ...props,
-        results: 20,
-        resultsPerPage: 5,
-        page: 1
-      }));
-      // assert correct starting page as page 2
-      expect(wrapper.find('.hods-pagination__link--current').text()).toEqual(
-        '2'
-      );
-      // click next button
-      wrapper.find('[id="nextButton"]').simulate('click');
-      // assert correct new page as page 3
-      expect(wrapper.find('.hods-pagination__link--current').text()).toEqual(
-        '3'
-      );
-      // check that the correct content is being shown on page 3
-      expect(wrapper.find('[id="11"]').exists()).toBeTruthy();
-      expect(wrapper.find('[id="12"]').exists()).toBeTruthy();
-      expect(wrapper.find('[id="13"]').exists()).toBeTruthy();
-      expect(wrapper.find('[id="14"]').exists()).toBeTruthy();
-      expect(wrapper.find('[id="15"]').exists()).toBeTruthy();
-      // check that the correct content is not being shown on page 3
-      expect(wrapper.find('[id="1"]').exists()).toBeFalsy();
-      expect(wrapper.find('[id="3"]').exists()).toBeFalsy();
-      expect(wrapper.find('[id="4"]').exists()).toBeFalsy();
-      expect(wrapper.find('[id="5"]').exists()).toBeFalsy();
-      expect(wrapper.find('[id="6"]').exists()).toBeFalsy();
-      expect(wrapper.find('[id="7"]').exists()).toBeFalsy();
-      expect(wrapper.find('[id="8"]').exists()).toBeFalsy();
-      expect(wrapper.find('[id="9"]').exists()).toBeFalsy();
-      expect(wrapper.find('[id="10"]').exists()).toBeFalsy();
-      expect(wrapper.find('[id="16"]').exists()).toBeFalsy();
-      expect(wrapper.find('[id="17"]').exists()).toBeFalsy();
-      expect(wrapper.find('[id="18"]').exists()).toBeFalsy();
-      expect(wrapper.find('[id="19"]').exists()).toBeFalsy();
-      expect(wrapper.find('[id="20"]').exists()).toBeFalsy();
-    });
-
-    it.skip('moves to the previous page when \'previous\' is clicked', () => {});
-
-    it.skip.each([1, 2, 3, 4])(
-      'moves to page when page number is clicked',
-      (number) => {}
-    );
-  });
-});
-
-describe('when given alternative valid props', () => {
-  const pagination = mount(
-    h(Pagination, {
-      results: 39,
-      resultsPerPage: 10,
-      page: 1
-    })
+      `Item #${i + 1}`
+    )
   );
 
-  let current;
-  beforeAll(() => {
-    expect(
-      (current = pagination.find('.hods-pagination__link--current'))
-    ).toHaveLength(1);
-  });
+  describe('when given minimal valid props', () => {
+    const pagination = mount(h(Pagination, minimalProps, children));
 
-  it('is on the correct page', () => {
-    expect(current.text()).toEqual('1');
-  });
+    const content = pagination.find('.hods-pagination__content');
+    const navigation = pagination.find('.hods-pagination__navigation');
 
-  it('should not have a link', () => {
-    expect(current.html()).toContain('href=""');
-  });
+    const summary = navigation.find('.hods-pagination__navigation__summary');
+    const current = navigation.find('A[aria-current="true"]').first();
 
-  const summary = pagination.find('.hods-pagination__summary').text();
+    it('shows the current page', () => expect(current.length).toEqual(1));
+    it('displays the first page', () => expect(current.text()).toEqual('1'));
+    it('displays the first element', () => expect(content.text()).toContain('Item #1'));
+    it('does NOT display the 11th element', () => expect(content.text()).not.toContain('Item #11'));
+    it('does NOT display the last element', () => expect(content.text()).not.toContain('Item #30'));
+    it('displays a summary', () => expect(summary.text()).toEqual('Showing 1 - 10 of 30 results'));
+    it('displays a link to the next page', () => expect(navigation.text()).toContain('Next'));
+    it('does NOT display a link to previous page', () => expect(navigation.text()).not.toContain('Previous'));
 
-  it('displays the correct value for results from', () => {
-    expect(summary.slice(8, 9)).toEqual('1');
-  });
-
-  it('displays the correct value for results to', () => {
-    expect(summary.slice(12, 14)).toEqual('10');
-  });
-
-  it('displays the correct value for total results', () => {
-    expect(summary.slice(18, 20)).toEqual('39');
-  });
-
-  const ul = pagination.find('.hods-pagination__list-items');
-  const prev = pagination.find('#prevButton');
-  const next = pagination.find('#nextButton');
-
-  it('does not display the previous link', () => {
-    expect(ul.childAt(0)).not.toEqual(prev);
-  });
-
-  it('displays the next link in the correct place', () => {
-    expect(ul.childAt(5)).toEqual(next);
+    describe.skip('when \'Next\' is clicked', () => {
+    });
   });
 });

--- a/components/pagination/src/Navigation.tsx
+++ b/components/pagination/src/Navigation.tsx
@@ -63,11 +63,13 @@ export const Navigation: FC<NavigationProps> = ({
         {page > 1 ? (
           <li
             className={classes('item')}
-            id="prevButton"
             key="prev"
-            aria-label={`Previous page, go to page ${page - 1}`}
           >
-            <A className={classes('link')} href={page > 1 ? hl[1] : ''}>
+            <A
+              className={classes('link')}
+              href={page > 1 ? hl[1] : ''}
+              aria-label={`Previous page, go to page ${page - 1}`}
+            >
               <span aria-hidden="true" role="presentation">
                 &laquo;
               </span>{' '}
@@ -99,13 +101,12 @@ export const Navigation: FC<NavigationProps> = ({
         {resultsTo == results ? null : (
           <li
             className={classes('item')}
-            id="nextButton"
             key="next"
-            aria-label={`Next page, go to page ${page + 1}`}
           >
             <A
               className={classes('link')}
               href={resultsTo == results ? '' : hl[3]}
+              aria-label={`Next page, go to page ${page + 1}`}
             >
               Next{' '}
               <span aria-hidden="true" role="presentation">

--- a/components/pagination/src/Navigation.tsx
+++ b/components/pagination/src/Navigation.tsx
@@ -1,0 +1,122 @@
+import { FC, createElement as h } from 'react';
+import { StandardProps, classBuilder } from '@not-govuk/component-helpers';
+import { A } from '@not-govuk/link';
+import { queryString } from '@not-govuk/route-utils';
+
+export type NavigationProps = StandardProps & {
+  /**The total number of results*/
+  results: number
+  /**The number of results shown on each page*/
+  resultsPerPage: number
+  /**The current page being viewed*/
+  page: number
+  /** Query parameter to use for the page number */
+  pageParameter?: string
+  /** Query object of the current page, to append to */
+  query?: object
+};
+
+export const Navigation: FC<NavigationProps> = ({
+  children,
+  classBlock,
+  classModifiers,
+  className,
+  results,
+  resultsPerPage,
+  page,
+  pageParameter = 'page',
+  query = {},
+  ...attrs
+}) => {
+  const classes = classBuilder(
+    'hods-pagination-navigation',
+    classBlock,
+    classModifiers,
+    className
+  );
+  const pageEquals = pageParameter + '=';
+
+  const resultsFrom = (page - 1) * resultsPerPage + 1;
+  const maxResults = page * resultsPerPage;
+  const additionalPage =
+    Math.floor(results / resultsPerPage) * resultsPerPage < results ? 1 : 0;
+  const maxPages = Math.floor(results / resultsPerPage) + additionalPage;
+
+  const resultsTo = results < maxResults ? results : maxResults;
+
+  const pages = [page - 2, page - 1, page, page + 1, page + 2];
+  const hl = [
+    queryString({ ...query, [pageParameter]: pages[0] }),
+    queryString({ ...query, [pageParameter]: pages[1] }),
+    '',
+    queryString({ ...query, [pageParameter]: pages[3] }),
+    queryString({ ...query, [pageParameter]: pages[4] })
+  ];
+  const it = [0, 1, 2, 3, 4];
+
+  return (
+    <nav className={classes()} role="navigation" aria-label="Pagination Navigation" {...attrs}>
+      <div className={classes('summary')}>
+        Showing {resultsFrom} - {resultsTo} of {results} results
+      </div>
+      <ul className={classes('list-items')}>
+        {page > 1 ? (
+          <li
+            className={classes('item')}
+            id="prevButton"
+            key="prev"
+            aria-label={`Previous page, go to page ${page - 1}`}
+          >
+            <A className={classes('link')} href={page > 1 ? hl[1] : ''}>
+              <span aria-hidden="true" role="presentation">
+                &laquo;
+              </span>{' '}
+              Previous
+            </A>
+          </li>
+        ) : null}
+        {it.map((i) => (
+          pages[i] < 1 || pages[i] > maxPages ? null : (
+            <li className={classes('item')} key={i}>
+              <A
+                className={classes(
+                  'link',
+                  pages[i] === page ? 'current' : undefined
+                )}
+                href={hl[i]}
+                aria-current={pages[i] === page ? 'true' : 'false' }
+                aria-label={
+                  pages[i] === page
+                    ? `Current page, page ${page}`
+                    : `Go to page ${page}`
+                }
+              >
+                {pages[i]}
+              </A>
+            </li>
+          )
+        ))}
+        {resultsTo == results ? null : (
+          <li
+            className={classes('item')}
+            id="nextButton"
+            key="next"
+            aria-label={`Next page, go to page ${page + 1}`}
+          >
+            <A
+              className={classes('link')}
+              href={resultsTo == results ? '' : hl[3]}
+            >
+              Next{' '}
+              <span aria-hidden="true" role="presentation">
+                &raquo;
+              </span>
+            </A>
+          </li>
+        )}
+      </ul>
+    </nav>
+  );
+};
+
+export default Navigation;

--- a/components/pagination/src/Pagination.tsx
+++ b/components/pagination/src/Pagination.tsx
@@ -1,26 +1,24 @@
-import React, { FC, createElement as h } from 'react';
+import { Children, FC, createElement as h } from 'react';
 import { StandardProps, classBuilder } from '@not-govuk/component-helpers';
 import { useLocation } from '@not-govuk/route-utils';
+import { Navigation } from './Navigation';
 
 import '../assets/Pagination.scss';
 
 export type PaginationProps = StandardProps & {
-  /**The total number of results*/
-  results: number
-  /**The number of results shown on each page*/
-  resultsPerPage: number
-  /**The current page being viewed*/
-  page: number
+  /** Number of items to be shown on each page */
+  size?: number
+  /** Query parameter to use for the page number */
+  pageParameter?: string
 };
 
 export const Pagination: FC<PaginationProps> = ({
-  children,
+  children: _children,
   classBlock,
   classModifiers,
   className,
-  results,
-  resultsPerPage,
-  page,
+  pageParameter = 'page',
+  size = 10,
   ...attrs
 }) => {
   const classes = classBuilder(
@@ -30,98 +28,18 @@ export const Pagination: FC<PaginationProps> = ({
     className
   );
   const location = useLocation();
+  const currentPage = Number(location?.query[pageParameter]) || 1;
 
-  //@ts-ignore
-  page = location.query.page ? Number(location.query.page) : Number(page);
-  results = Number(results);
-  resultsPerPage = Number(resultsPerPage);
-
-  const resultsFrom = (page - 1) * resultsPerPage + 1;
-  const maxResults = page * resultsPerPage;
-  const additionalPage =
-    Math.floor(results / resultsPerPage) * resultsPerPage < results ? 1 : 0;
-  const maxPages = Math.floor(results / resultsPerPage) + additionalPage;
-
-  const resultsTo = results < maxResults ? results : maxResults;
-
-  const pages = [page - 2, page - 1, page, page + 1, page + 2];
-  const it = [0, 1, 2, 3, 4];
-  const hl = [
-    '?page=' + pages[0],
-    '?page=' + pages[1],
-    '',
-    '?page=' + pages[3],
-    '?page=' + pages[4],
-  ];
+  const items = Children.toArray(_children);
+  const start = size * (currentPage - 1);
+  const children = items.slice(start, start + size);
 
   return (
-    <div className={classes()}>
+    <div className={classes()} {...attrs}>
       <div className={classes('content')}>
-        {React.Children.map(children, (child, index) => {
-          if (index + 1 >= resultsFrom && index + 1 <= resultsTo) return child;
-        })}
+        {children}
       </div>
-      <nav role="navigation" aria-label="Pagination Navigation">
-        <div className={classes('summary')}>
-          Showing {resultsFrom} - {resultsTo} of {results} results
-        </div>
-        <ul className={classes('list-items')}>
-          {page > 1 ? (
-            <li
-              className={classes('item')}
-              id="prevButton"
-              key="prev"
-              aria-label={`Previous page, go to page ${page - 1}`}
-            >
-              <a className={classes('link')} href={page > 1 ? hl[1] : ''}>
-                <span aria-hidden="true" role="presentation">
-                  &laquo;
-                </span>{' '}
-                Previous
-              </a>
-            </li>
-          ) : null}
-          {it.map((i) => (
-            <li className={classes('item')} key={i}>
-              {pages[i] < 1 || pages[i] > maxPages ? null : (
-                <a
-                  className={classes(
-                    'link',
-                    pages[i] === page ? 'current' : undefined
-                  )}
-                  href={hl[i]}
-                  aria-current={pages[i] === page ? true : false}
-                  aria-label={
-                    pages[i] === page
-                      ? `Current page, page ${page}`
-                      : `Go to page ${page}`
-                  }
-                >
-                  {pages[i]}
-                </a>
-              )}
-            </li>
-          ))}
-          {resultsTo == results ? null : (
-            <li
-              className={classes('item')}
-              id="nextButton"
-              key="next"
-              aria-label={`Next page, go to page ${page + 1}`}
-            >
-              <a
-                className={classes('link')}
-                href={resultsTo == results ? '' : hl[3]}
-              >
-                Next{' '}
-                <span aria-hidden="true" role="presentation">
-                  &raquo;
-                </span>
-              </a>
-            </li>
-          )}
-        </ul>
-      </nav>
+      <Navigation classBlock={classes('navigation')} pageParameter={pageParameter} page={currentPage} query={location.query} results={items.length} resultsPerPage={size} />
     </div>
   );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -362,6 +362,7 @@ importers:
       '@mdx-js/react': 1.6.22
       '@not-govuk/component-helpers': ^0.5.7
       '@not-govuk/component-test-helpers': ^0.5.7
+      '@not-govuk/link': ^0.5.7
       '@not-govuk/route-utils': ^0.5.7
       '@types/react': 16.14.24
       jest: 28.1.3
@@ -371,6 +372,7 @@ importers:
     dependencies:
       '@hods/sass-base': link:../../lib/sass-base
       '@not-govuk/component-helpers': 0.5.7
+      '@not-govuk/link': 0.5.7_96a2fb6b151fd54b8763b130fdb2d926
       '@not-govuk/route-utils': 0.5.7_react-router-dom@5.3.3
     devDependencies:
       '@jest/globals': 28.1.3


### PR DESCRIPTION
Fixes a bug in which the query parameters of the current page were lost
when clicking the links.

Moves the original 'navigation' into its own sub-component.

Simplifies the tests.

**BREAKING:** Simplifies the interface, children now _must_ be provided.