### PR TITLE
Remove writing from help improve this component

### DIFF
--- a/components/status-message/spec/StatusMessage.stories.mdx
+++ b/components/status-message/spec/StatusMessage.stories.mdx
@@ -108,7 +108,6 @@ Research with 6 users showed that users understood the message and how to intera
 
 This component needs improving. We need evidence about:
 
-- how to write for this component
 - when to use an [alert](/components?name=Alert), [expandable banner](/components?name=Expandable%20banner) or status message
 
 To contribute, add your thoughts and research findings to our [GitHub discussion](https://github.com/UKHomeOffice/design-system/discussions/419), or follow our [contribute guidance](/contribute).


### PR DESCRIPTION
This change simply removes the line on the status message component about needing to add a writing for this component section.

This was missed when approving and deploying https://github.com/UKHomeOffice/design-system/pull/463 - writing for status messages.