### PR TITLE
Remove all whitespace from time

### DIFF
--- a/components/time/src/utils.ts
+++ b/components/time/src/utils.ts
@@ -10,7 +10,7 @@ export const formatTime = (
 		    hour: clockType === 24 ? '2-digit' : 'numeric',
 		    minute: '2-digit'
 		  })
-		  .replace(' ','')
+		  .replace(/\s+/g,'')
       .toLowerCase()
 	);
 };


### PR DESCRIPTION
Generalised to remove all whitespace from time, rather than just spaces. This is because in newer version of node the whitespace between the time and am or pm has changed from a space (Unicode 32) to a narrow no-break space (Unicode 8239). Fixes issue https://github.com/UKHomeOffice/design-system/issues/492.