### PR TITLE
Page: Add custom styling to secondary buttons

### DIFF
--- a/components/page/assets/Page.scss
+++ b/components/page/assets/Page.scss
@@ -4,6 +4,14 @@
 @import "govuk-frontend/govuk/objects/_template";
 @import "./fonts/roboto.scss";
 
+$hods-secondary-button-colour: #F8F8F8;
+$hods-secondary-button-hover-colour: govuk-shade($hods-secondary-button-colour, 10%);
+$hods-secondary-button-shadow-colour: govuk-colour("black"); // was: govuk-shade($hods-secondary-button-colour, 40%);
+$hods-secondary-button-text-colour: govuk-colour("black");
+$hods-secondary-button-border-width: 1px;
+
+$button-shadow-size: $govuk-border-width-form-element;
+
 .hods-page,
 #story-root,
 #root,
@@ -36,6 +44,43 @@ html {
   &__body {
     flex: 1 1 auto;
     width: 100%;
+
+    // The style of the secondary button needs to change due to the grey background of .hods-page
+    .govuk-button--secondary {
+      background-color: $hods-secondary-button-colour;
+      // We make the, now visible, borders smaller
+      border-color: $hods-secondary-button-shadow-colour;
+      border-width: $hods-secondary-button-border-width $hods-secondary-button-border-width 0 $hods-secondary-button-border-width;
+      // Padding must be adjusted to account for new border size
+      padding: (govuk-spacing(2) - $hods-secondary-button-border-width)
+               (govuk-spacing(2) + $govuk-border-width-form-element - $hods-secondary-button-border-width)
+               (govuk-spacing(2) - ($button-shadow-size / 2));
+      box-shadow: 0 $button-shadow-size 0 $hods-secondary-button-shadow-colour;
+
+      &,
+      &:link,
+      &:visited,
+      &:active,
+      &:hover {
+        color: $hods-secondary-button-text-colour;
+      }
+
+      &:hover {
+        background-color: $hods-secondary-button-hover-colour;
+
+        &[disabled] {
+          background-color: $hods-secondary-button-colour;
+        }
+      }
+
+      &:focus {
+        // Must reinstate original border widths and padding
+        border-width: $govuk-border-width-form-element;
+        padding: (govuk-spacing(2) - $govuk-border-width-form-element)
+                 govuk-spacing(2)
+                 (govuk-spacing(2) - $govuk-border-width-form-element - ($button-shadow-size / 2));
+      }
+    }
   }
 
   &__container {

--- a/components/page/package.json
+++ b/components/page/package.json
@@ -47,6 +47,8 @@
   "devDependencies": {
     "@mdx-js/react": "1.6.22",
     "@not-govuk/component-test-helpers": "^0.7.2",
+    "@not-govuk/button-group": "^0.7.2",
+    "@not-govuk/button": "^0.7.2",
     "@types/react": "16.14.38",
     "jest": "29.5.0",
     "jest-environment-jsdom": "29.5.0",

--- a/components/page/spec/Page.stories.mdx
+++ b/components/page/spec/Page.stories.mdx
@@ -1,4 +1,6 @@
 import { Meta, Preview, Props, Story } from '@storybook/addon-docs';
+import { Button } from '@not-govuk/button';
+import { ButtonGroup } from '@not-govuk/button-group';
 import { Page } from '../src/Page';
 import readMe from '../README.md';
 
@@ -29,6 +31,11 @@ Use this page template to keep your pages consistent with the rest of internal H
     >
       <h1>Default page template</h1>
       <p>The header inspires trust with the department logo, while the service name helps users understand which service they are using.</p>
+      <p>The main page content has a grey background to reduce eye-strain. Buttons in this section are slightly re-styled, for accessibility reasons.</p>
+      <ButtonGroup>
+        <Button>Save and continue</Button>
+        <Button classModifiers="secondary">Save as draft</Button>
+      </ButtonGroup>
       <p>The footer includes information about the department with relevant links. White background helps to clearly section the main content area.</p>
     </Page>
   </Story>
@@ -44,6 +51,11 @@ Use this page template to keep your pages consistent with the rest of internal H
     <Page>
       <h1>Default page template</h1>
       <p>The header inspires trust with the department logo, while the service name helps users understand which service they are using.</p>
+      <p>The main page content has a grey background to reduce eye-strain. Buttons in this section are slightly re-styled, for accessibility reasons.</p>
+      <ButtonGroup>
+        <Button>Save and continue</Button>
+        <Button classModifiers="secondary">Save as draft</Button>
+      </ButtonGroup>
       <p>The footer includes information about the department with relevant links. White background helps to clearly section the main content area.</p>
     </Page>
   </Story>
@@ -74,10 +86,16 @@ Use this page template to keep your pages consistent with the rest of internal H
     >
       <h1>Default page template</h1>
       <p>The header inspires trust with the department logo, while the service name helps users understand which service they are using.</p>
+      <p>The main page content has a grey background to reduce eye-strain. Buttons in this section are slightly re-styled, for accessibility reasons.</p>
+      <ButtonGroup>
+        <Button>Save and continue</Button>
+        <Button classModifiers="secondary">Save as draft</Button>
+      </ButtonGroup>
       <p>The footer includes information about the department with relevant links. White background helps to clearly section the main content area.</p>
     </Page>
   </Story>
 </Preview>
+
 
 ## Accessibility
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -395,6 +395,8 @@ importers:
       '@hods/header': workspace:^0.4.0
       '@hods/sass-base': workspace:^0.4.0
       '@mdx-js/react': 1.6.22
+      '@not-govuk/button': ^0.7.2
+      '@not-govuk/button-group': ^0.7.2
       '@not-govuk/component-helpers': ^0.7.2
       '@not-govuk/component-test-helpers': ^0.7.2
       '@not-govuk/skip-link': ^0.7.2
@@ -413,6 +415,8 @@ importers:
       govuk-frontend: 4.4.1
     devDependencies:
       '@mdx-js/react': 1.6.22
+      '@not-govuk/button': 0.7.2
+      '@not-govuk/button-group': 0.7.2
       '@not-govuk/component-test-helpers': 0.7.2
       '@types/react': 16.14.38
       jest: 29.5.0
@@ -4844,7 +4848,6 @@ packages:
       react-router-hash-link: 2.4.3
     transitivePeerDependencies:
       - react-router-dom
-    dev: false
 
   /@not-govuk/anchor/0.7.2_jocyui6jwueadhqfh525qglyzq:
     resolution: {integrity: sha512-XG7gVsYExxdjhqGnrlQDUOv3WsF45YqNKTOaxuERDP2LPsumh2jcLrspLSu4F9u2BgdmzNjoECbGK4+CEsl/NA==}
@@ -5059,6 +5062,23 @@ packages:
       - react-router-dom
     dev: true
 
+  /@not-govuk/button-group/0.7.2:
+    resolution: {integrity: sha512-IltOAn5H27NHtxd/tyh8QNHQcSK/vheHQ/G+y1S29ZuSVNnNE7lnEmrTKVjVZixdq+2nZfmP/SSMRcqqtg20ig==}
+    peerDependencies:
+      '@not-govuk/docs-components': ^0.7.2
+      '@storybook/addon-docs': ^6.4.0
+      react: ^16.9.55
+    peerDependenciesMeta:
+      '@not-govuk/docs-components':
+        optional: true
+      '@storybook/addon-docs':
+        optional: true
+    dependencies:
+      '@not-govuk/component-helpers': 0.7.2
+      '@not-govuk/sass-base': 0.7.2
+      govuk-frontend: 4.4.1
+    dev: true
+
   /@not-govuk/button-group/0.7.2_react@16.14.0:
     resolution: {integrity: sha512-IltOAn5H27NHtxd/tyh8QNHQcSK/vheHQ/G+y1S29ZuSVNnNE7lnEmrTKVjVZixdq+2nZfmP/SSMRcqqtg20ig==}
     peerDependencies:
@@ -5095,6 +5115,26 @@ packages:
       '@storybook/addon-docs': 6.5.16_fijkficcb77iescfrgc5hfm56u
       govuk-frontend: 4.4.1
       react: 16.14.0
+    dev: true
+
+  /@not-govuk/button/0.7.2:
+    resolution: {integrity: sha512-hALvDJ+vvLRkHMBnLB/5ZeGrrN/ZAbEkuKRzyotlhsMWlqwAXp2eUWJBu7okWBt/SqL/oyhTxPbmLhpQKXsCsQ==}
+    peerDependencies:
+      '@not-govuk/docs-components': ^0.7.2
+      '@storybook/addon-docs': ^6.4.0
+      react: ^16.9.55
+    peerDependenciesMeta:
+      '@not-govuk/docs-components':
+        optional: true
+      '@storybook/addon-docs':
+        optional: true
+    dependencies:
+      '@not-govuk/component-helpers': 0.7.2
+      '@not-govuk/link': 0.7.2
+      '@not-govuk/sass-base': 0.7.2
+      govuk-frontend: 4.4.1
+    transitivePeerDependencies:
+      - react-router-dom
     dev: true
 
   /@not-govuk/button/0.7.2_jocyui6jwueadhqfh525qglyzq:
@@ -6123,7 +6163,6 @@ packages:
       govuk-frontend: 4.4.1
     transitivePeerDependencies:
       - react-router-dom
-    dev: false
 
   /@not-govuk/link/0.7.2_jocyui6jwueadhqfh525qglyzq:
     resolution: {integrity: sha512-neI8HjGcLuJ70co87UIm53qf+euh5/wfcMayGI6XkfExeFAcBpXEdIzFuMAlMCihUzEyo7G2F4WQAW97u95Law==}
@@ -6504,7 +6543,6 @@ packages:
       history: 4.10.1
       qs: 6.11.2
       url-parse: 1.5.10
-    dev: false
 
   /@not-govuk/route-utils/0.7.2_react-router-dom@5.3.4:
     resolution: {integrity: sha512-qP/BN5gMR8D+XGXvdpGKWkjBieJxMQtdq8OlmPLsXEGzC4I/u9naHBfO7sI1fQdgIil9Jk480QVT6NLVUO1SEw==}
@@ -18961,7 +18999,6 @@ packages:
       react-router-dom: '>=4'
     dependencies:
       prop-types: 15.8.1
-    dev: false
 
   /react-router-hash-link/2.4.3_jocyui6jwueadhqfh525qglyzq:
     resolution: {integrity: sha512-NU7GWc265m92xh/aYD79Vr1W+zAIXDWp3L2YZOYP4rCqPnJ6LI6vh3+rKgkidtYijozHclaEQTAHaAaMWPVI4A==}


### PR DESCRIPTION
The grey background causes accessibility issues when used with secondary
buttons. This overrides some of the styling to provide a black border
for the button.

This is an alternative implementation to #518.

closes: #515