### PR TITLE
Update description of background colour

### DIFF
--- a/apps/docs/src/common/pages/styles/colour.tsx
+++ b/apps/docs/src/common/pages/styles/colour.tsx
@@ -66,9 +66,9 @@ const Page: FC<PageProps> = ({ location }) => (
 
         <h3 className="govuk-heading-m" style={{marginTop: "1.5em", marginBottom: "0.5em"}}>Page background</h3>
         <div className="colour-swatch">
-          <span className="app-swatch" style={{backgroundColor: "#f1f1f1", border: "1px solid #CBCBCB"}}></span>
+          <span className="app-swatch" style={{backgroundColor: "#f5f5f5", border: "1px solid #CBCBCB"}}></span>
           <div className="hex">
-            #f1f1f1
+            #f5f5f5
           </div>
           <div className="colour-info">
             <p>


### PR DESCRIPTION
#531 raises that the background colour of the Home Office Design System is different to the one on the 'Colour' page of the design system.

This fixes this issue and updates the colour page to #f5f5f5