### PR TITLE
Fix broken install pnpm link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,6 @@ We publish our documentation site when pushing to the `master` branch.
 [components/]: ./components/
 [pnpm-workspaces.yaml]: ./pnpm-workspaces.yaml
 [plopfile.js]: ./plopfile.js
-[install pnpm]: https://pnpm.js.org/en/installation
+[install pnpm]: https://pnpm.io/installation
 [PLOP]: https://plopjs.com/
 [documentation application]: ./apps/docs


### PR DESCRIPTION
"Install pnpm" link in the readme "Getting Started" section was broken because pnpm site has switched domains. I've replaced the link with correct one.

Fixes #569.

Thank you.