### PR TITLE
Fix: Failing Build on scan-app Action

### DIFF
--- a/.github/actions/scan-app/action.yml
+++ b/.github/actions/scan-app/action.yml
@@ -37,7 +37,7 @@ runs:
 
     - name: ZAP Scan (baseline)
       if: inputs.smoke
-      uses: zaproxy/action-baseline@v0.7.0
+      uses: zaproxy/action-baseline@v0.12.0
       with:
         token: ${{ inputs.token }}
         target: ${{ steps.info.outputs.target }}
@@ -49,7 +49,7 @@ runs:
 
     - name: ZAP Scan (full)
       if: ${{ !inputs.smoke }}
-      uses: zaproxy/action-full-scan@v0.4.0
+      uses: zaproxy/action-full-scan@v0.10.0
       with:
         token: ${{ inputs.token }}
         target: ${{ steps.info.outputs.target }}


### PR DESCRIPTION
Good afternoon.

"Scan service for vulnerabilities" workflow was failing because `owasp/zap2docker` Docker image does not exist any longer, it has been deprecated and replaced with `owasp/zaproxy` image with following error:

```
Error response from daemon: pull access denied for owasp/zap2docker, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```

I have upgraded two actions in this workflow:

- zaproxy/action-baseline (v0.4.0 -> v0.10.0)
- zaproxy/action-full-scan (v0.7.0 -> v0.12.0)

This should fix the failing scan. 

Thank you.