### PR TITLE
Markdown workaround for UCDM

### DIFF
--- a/apps/docs/src/common/pages/community/events/index.mdx
+++ b/apps/docs/src/common/pages/community/events/index.mdx
@@ -6,6 +6,7 @@ import { Subsection } from '@hods/ucdm-subsection';
 import config from '../../../config';
 
 import { SectionWrap, title as section } from '../index.mdx';
+import Markdown from '../../../../../../../docs/community/events/README.md';
 
 export const title = 'Community events';
 const longTitle = title;
@@ -32,11 +33,6 @@ export const SubsectionWrap = ({ children }) => (
     <meta name="og:title" content={title} />
     <meta name="og:description" content={description} />
   </head>
-  <h1>
-    <span className="caption">{section}</span>
-    {longTitle}
-  </h1>
-
-CONTENT PLACEHOLDER
-
+  <span className="govuk-caption-xl">{section}</span>
+  <Markdown />
 </SubsectionWrap>

--- a/apps/docs/src/common/pages/community/index.mdx
+++ b/apps/docs/src/common/pages/community/index.mdx
@@ -6,6 +6,7 @@ import { Section } from '@hods/ucdm-section';
 import config from '../../config';
 
 import { PageWrap } from '../ucdm';
+import Markdown from '../../../../../../docs/community/README.md';
 
 export const title = 'Community';
 const longTitle = 'User-centred design community';
@@ -34,9 +35,6 @@ export const SectionWrap = ({ children }) => (
       <meta name="og:title" content={title} />
       <meta name="og:description" content={description} />
     </head>
-    <h1>{longTitle}</h1>
-
-CONTENT PLACEHOLDER
-
+    <Markdown />
   </main>
 </SectionWrap>

--- a/apps/docs/src/common/pages/community/new-starters/index.mdx
+++ b/apps/docs/src/common/pages/community/new-starters/index.mdx
@@ -6,6 +6,7 @@ import { Subsection } from '@hods/ucdm-subsection';
 import config from '../../../config';
 
 import { SectionWrap, title as section } from '../index.mdx';
+import Markdown from '../../../../../../../docs/community/new-starters/README.md';
 
 export const title = 'New starters';
 const longTitle = title;
@@ -32,11 +33,6 @@ export const SubsectionWrap = ({ children }) => (
     <meta name="og:title" content={title} />
     <meta name="og:description" content={description} />
   </head>
-  <h1>
-    <span className="caption">{section}</span>
-    {longTitle}
-  </h1>
-
-CONTENT PLACEHOLDER
-
+  <span className="govuk-caption-xl">{section}</span>
+  <Markdown />
 </SubsectionWrap>

--- a/apps/docs/src/common/pages/community/training/index.mdx
+++ b/apps/docs/src/common/pages/community/training/index.mdx
@@ -6,6 +6,7 @@ import { Subsection } from '@hods/ucdm-subsection';
 import config from '../../../config';
 
 import { SectionWrap, title as section } from '../index.mdx';
+import Markdown from '../../../../../../../docs/community/training/README.md';
 
 export const title = 'Training';
 const longTitle = title;
@@ -32,11 +33,6 @@ export const SubsectionWrap = ({ children }) => (
     <meta name="og:title" content={title} />
     <meta name="og:description" content={description} />
   </head>
-  <h1>
-    <span className="caption">{section}</span>
-    {longTitle}
-  </h1>
-
-CONTENT PLACEHOLDER
-
+  <span className="govuk-caption-xl">{section}</span>
+  <Markdown />
 </SubsectionWrap>

--- a/apps/docs/src/common/pages/community/ucd-ops-team/index.mdx
+++ b/apps/docs/src/common/pages/community/ucd-ops-team/index.mdx
@@ -6,6 +6,7 @@ import { Subsection } from '@hods/ucdm-subsection';
 import config from '../../../config';
 
 import { SectionWrap, title as section } from '../index.mdx';
+import Markdown from '../../../../../../../docs/community/ucd-ops-team/README.md';
 
 export const title = 'UCD Ops';
 const longTitle = 'User-centred design ops';
@@ -32,11 +33,6 @@ export const SubsectionWrap = ({ children }) => (
     <meta name="og:title" content={title} />
     <meta name="og:description" content={description} />
   </head>
-  <h1>
-    <span className="caption">{section}</span>
-    {longTitle}
-  </h1>
-
-CONTENT PLACEHOLDER
-
+  <span className="govuk-caption-xl">{section}</span>
+  <Markdown />
 </SubsectionWrap>

--- a/apps/docs/src/common/pages/design-and-content/content/content-patterns.tsx
+++ b/apps/docs/src/common/pages/design-and-content/content/content-patterns.tsx
@@ -1,10 +1,10 @@
 import { FC, createElement as h } from 'react';
 import { Helmet } from 'react-helmet-async';
 import { PageProps } from '@not-govuk/app-composer';
-import { A } from '@not-govuk/components';
 import config from '../../../config';
 
 import { SubsectionWrap, title as subsection } from './';
+import Markdown from '../../../../../../../docs/design-and-content/content/content-patterns.md';
 
 const siteTitle = config.title;
 
@@ -20,15 +20,9 @@ const Page: FC<PageProps> = () => (
       <meta name="og:title" content={title} />
       <meta name="og:description" content={description} />
     </Helmet>
-    <h1>
-      <span className="caption">{subsection}</span>
-      {longTitle}
-    </h1>
-    <p>CONTENT PLACEHOLDER.</p>
+    <span className="govuk-caption-xl">{subsection}</span>
+    <Markdown />
   </SubsectionWrap>
 );
 
 export default Page;
-  
-
-

--- a/apps/docs/src/common/pages/design-and-content/content/index.tsx
+++ b/apps/docs/src/common/pages/design-and-content/content/index.tsx
@@ -7,6 +7,7 @@ import { Subsection } from '@hods/ucdm-subsection';
 import config from '../../../config';
 
 import { SectionWrap, title as section } from '../';
+import Markdown from '../../../../../../../docs/design-and-content/content/README.md';
 
 const siteTitle = config.title;
 
@@ -21,6 +22,10 @@ export const SubsectionWrap: FC<{ children?: ReactNode }> = ({ children }) => (
         {
           href: '/design-and-content/content/content-style-guide',
           text: 'Content style guide'
+        },
+        {
+          href: '/design-and-content/content/content-patterns',
+          text: 'Content patterns'
         },
         {
           href: '/accessibility/written-content/inclusive-language',
@@ -53,11 +58,8 @@ const Page: FC<PageProps> = () => (
       <meta name="og:title" content={title} />
       <meta name="og:description" content={description} />
     </Helmet>
-    <h1>
-      <span className="caption">{section}</span>
-      {longTitle}
-    </h1>
-    <p>CONTENT PLACEHOLDER.</p>
+    <span className="govuk-caption-xl">{section}</span>
+    <Markdown />
   </SubsectionWrap>
 );
 

--- a/apps/docs/src/common/pages/design-and-content/professional-standards/approved-tools.mdx
+++ b/apps/docs/src/common/pages/design-and-content/professional-standards/approved-tools.mdx
@@ -5,6 +5,7 @@ import { A, NavigationMenu } from '@not-govuk/components';
 import config from '../../../config';
 
 import { SubsectionWrap, title as subsection } from './index.mdx';
+import Markdown from '../../../../../../../docs/design-and-content/professional-standards/approved-tools.md';
 
 export const title = 'Approved tools';
 const longTitle = title;
@@ -19,11 +20,6 @@ const pageTitle = title + ' - ' + siteTitle;
     <meta name="og:title" content={title} />
     <meta name="og:description" content={description} />
   </head>
-  <h1>
-    <span className="caption">{subsection}</span>
-    {longTitle}
-  </h1>
-
-CONTENT PLACEHOLDER
-
+  <span className="govuk-caption-xl">{subsection}</span>
+  <Markdown />
 </SubsectionWrap>

--- a/apps/docs/src/common/pages/design-and-content/professional-standards/designer-role-standard.mdx
+++ b/apps/docs/src/common/pages/design-and-content/professional-standards/designer-role-standard.mdx
@@ -5,6 +5,7 @@ import { A, NavigationMenu } from '@not-govuk/components';
 import config from '../../../config';
 
 import { SubsectionWrap, title as subsection } from './index.mdx';
+import Markdown from '../../../../../../../docs/design-and-content/professional-standards/designer-role-standard.md';
 
 export const title = 'Designer role standards';
 const longTitle = title;
@@ -19,11 +20,6 @@ const pageTitle = title + ' - ' + siteTitle;
     <meta name="og:title" content={title} />
     <meta name="og:description" content={description} />
   </head>
-  <h1>
-    <span className="caption">{subsection}</span>
-    {longTitle}
-  </h1>
-
-CONTENT PLACEHOLDER
-
+  <span className="govuk-caption-xl">{subsection}</span>
+  <Markdown />
 </SubsectionWrap>

--- a/apps/docs/src/common/pages/design-and-content/professional-standards/index.mdx
+++ b/apps/docs/src/common/pages/design-and-content/professional-standards/index.mdx
@@ -6,6 +6,7 @@ import { Subsection } from '@hods/ucdm-subsection';
 import config from '../../../config';
 
 import { SectionWrap, title as section } from '../';
+import Markdown from '../../../../../../../docs/design-and-content/professional-standards/README.md';
 
 export const title = 'Professional standards and guidance';
 const longTitle = title;
@@ -34,11 +35,6 @@ export const SubsectionWrap = ({ children }) => (
     <meta name="og:title" content={title} />
     <meta name="og:description" content={description} />
   </head>
-  <h1>
-    <span className="caption">{section}</span>
-    {longTitle}
-  </h1>
-
-CONTENT PLACEHOLDER
-
+  <span className="govuk-caption-xl">{section}</span>
+  <Markdown />
 </SubsectionWrap>

--- a/apps/docs/src/common/pages/design-and-content/professional-standards/project-on-off-boarding.mdx
+++ b/apps/docs/src/common/pages/design-and-content/professional-standards/project-on-off-boarding.mdx
@@ -5,6 +5,7 @@ import { A, NavigationMenu } from '@not-govuk/components';
 import config from '../../../config';
 
 import { SubsectionWrap, title as subsection } from './index.mdx';
+import Markdown from '../../../../../../../docs/design-and-content/professional-standards/project-on-off-boarding.md';
 
 export const title = 'Project on/off-boarding';
 const longTitle = 'Project on-boarding and off-boarding';
@@ -19,11 +20,6 @@ const pageTitle = title + ' - ' + siteTitle;
     <meta name="og:title" content={title} />
     <meta name="og:description" content={description} />
   </head>
-  <h1>
-    <span className="caption">{subsection}</span>
-    {longTitle}
-  </h1>
-
-CONTENT PLACEHOLDER
-
+  <span className="govuk-caption-xl">{subsection}</span>
+  <Markdown />
 </SubsectionWrap>

--- a/apps/docs/src/common/pages/user-research/ethics/consent.mdx
+++ b/apps/docs/src/common/pages/user-research/ethics/consent.mdx
@@ -5,6 +5,7 @@ import { A, NavigationMenu } from '@not-govuk/components';
 import config from '../../../config';
 
 import { SubsectionWrap, title as subsection } from './index.mdx';
+import Markdown from '../../../../../../../docs/user-research/ethics/consent.md';
 
 export const title = 'Consent';
 const longTitle = title;
@@ -19,11 +20,6 @@ const pageTitle = title + ' - ' + siteTitle;
     <meta name="og:title" content={title} />
     <meta name="og:description" content={description} />
   </head>
-  <h1>
-    <span className="caption">{subsection}</span>
-    {longTitle}
-  </h1>
-
-CONTENT PLACEHOLDER
-
+  <span className="govuk-caption-xl">{subsection}</span>
+  <Markdown />
 </SubsectionWrap>

--- a/apps/docs/src/common/pages/user-research/ethics/index.mdx
+++ b/apps/docs/src/common/pages/user-research/ethics/index.mdx
@@ -6,6 +6,7 @@ import { Subsection } from '@hods/ucdm-subsection';
 import config from '../../../config';
 
 import { SectionWrap, title as section } from '../index.mdx';
+import Markdown from '../../../../../../../docs/user-research/ethics/README.md';
 
 export const title = 'Ethics';
 const longTitle = 'Ethical research and consent';
@@ -32,11 +33,6 @@ export const SubsectionWrap = ({ children }) => (
     <meta name="og:title" content={title} />
     <meta name="og:description" content={description} />
   </head>
-  <h1>
-    <span className="caption">{section}</span>
-    {longTitle}
-  </h1>
-
-CONTENT PLACEHOLDER
-
+  <span className="govuk-caption-xl">{section}</span>
+  <Markdown />
 </SubsectionWrap>

--- a/apps/docs/src/common/pages/user-research/index.mdx
+++ b/apps/docs/src/common/pages/user-research/index.mdx
@@ -6,6 +6,7 @@ import { Section } from '@hods/ucdm-section';
 import config from '../../config';
 
 import { PageWrap } from '../ucdm';
+import Markdown from '../../../../../../docs/user-research/README.md';
 
 export const title = 'User research';
 const longTitle = title;
@@ -33,9 +34,6 @@ export const SectionWrap = ({ children }) => (
       <meta name="og:title" content={title} />
       <meta name="og:description" content={description} />
     </head>
-    <h1>{longTitle}</h1>
-
-CONTENT PLACEHOLDER
-
+    <Markdown />
   </main>
 </SectionWrap>

--- a/apps/docs/src/common/pages/user-research/participant-recruitment/index.mdx
+++ b/apps/docs/src/common/pages/user-research/participant-recruitment/index.mdx
@@ -6,6 +6,7 @@ import { Subsection } from '@hods/ucdm-subsection';
 import config from '../../../config';
 
 import { SectionWrap, title as section } from '../index.mdx';
+import Markdown from '../../../../../../../docs/user-research/participant-recruitment/README.md';
 
 export const title = 'Participant recruitment';
 const longTitle = title;
@@ -32,11 +33,6 @@ export const SubsectionWrap = ({ children }) => (
     <meta name="og:title" content={title} />
     <meta name="og:description" content={description} />
   </head>
-  <h1>
-    <span className="caption">{section}</span>
-    {longTitle}
-  </h1>
-
-CONTENT PLACEHOLDER
-
+  <span className="govuk-caption-xl">{section}</span>
+  <Markdown />
 </SubsectionWrap>

--- a/apps/docs/src/common/pages/user-research/professional-standards/approved-tools.mdx
+++ b/apps/docs/src/common/pages/user-research/professional-standards/approved-tools.mdx
@@ -5,6 +5,7 @@ import { A, NavigationMenu } from '@not-govuk/components';
 import config from '../../../config';
 
 import { SubsectionWrap, title as subsection } from './index.mdx';
+import Markdown from '../../../../../../../docs/user-research/professional-standards/approved-tools.md';
 
 export const title = 'Approved tools';
 const longTitle = title;
@@ -19,11 +20,6 @@ const pageTitle = title + ' - ' + siteTitle;
     <meta name="og:title" content={title} />
     <meta name="og:description" content={description} />
   </head>
-  <h1>
-    <span className="caption">{subsection}</span>
-    {longTitle}
-  </h1>
-
-CONTENT PLACEHOLDER
-
+  <span className="govuk-caption-xl">{subsection}</span>
+  <Markdown />
 </SubsectionWrap>

--- a/apps/docs/src/common/pages/user-research/professional-standards/index.mdx
+++ b/apps/docs/src/common/pages/user-research/professional-standards/index.mdx
@@ -6,6 +6,7 @@ import { Subsection } from '@hods/ucdm-subsection';
 import config from '../../../config';
 
 import { SectionWrap, title as section } from '../index.mdx';
+import Markdown from '../../../../../../../docs/user-research/professional-standards/README.md';
 
 export const title = 'Professional standards and guidance';
 const longTitle = title;
@@ -34,11 +35,6 @@ export const SubsectionWrap = ({ children }) => (
     <meta name="og:title" content={title} />
     <meta name="og:description" content={description} />
   </head>
-  <h1>
-    <span className="caption">{section}</span>
-    {longTitle}
-  </h1>
-
-CONTENT PLACEHOLDER
-
+  <span className="govuk-caption-xl">{section}</span>
+  <Markdown />
 </SubsectionWrap>

--- a/apps/docs/src/common/pages/user-research/professional-standards/project-on-off-boarding.mdx
+++ b/apps/docs/src/common/pages/user-research/professional-standards/project-on-off-boarding.mdx
@@ -5,6 +5,7 @@ import { A, NavigationMenu } from '@not-govuk/components';
 import config from '../../../config';
 
 import { SubsectionWrap, title as subsection } from './index.mdx';
+import Markdown from '../../../../../../../docs/user-research/professional-standards/project-on-off-boarding.md';
 
 export const title = 'Project on/off-boarding';
 const longTitle = 'Project on-boarding and off-boarding';
@@ -19,11 +20,6 @@ const pageTitle = title + ' - ' + siteTitle;
     <meta name="og:title" content={title} />
     <meta name="og:description" content={description} />
   </head>
-  <h1>
-    <span className="caption">{subsection}</span>
-    {longTitle}
-  </h1>
-
-CONTENT PLACEHOLDER
-
+  <span className="govuk-caption-xl">{subsection}</span>
+  <Markdown />
 </SubsectionWrap>

--- a/apps/docs/src/common/pages/user-research/professional-standards/user-researcher-role-standard.mdx
+++ b/apps/docs/src/common/pages/user-research/professional-standards/user-researcher-role-standard.mdx
@@ -5,6 +5,7 @@ import { A, NavigationMenu } from '@not-govuk/components';
 import config from '../../../config';
 
 import { SubsectionWrap, title as subsection } from './index.mdx';
+import Markdown from '../../../../../../../docs/user-research/professional-standards/user-researcher-role-standard.md';
 
 export const title = 'User researcher role standards';
 const longTitle = title;
@@ -19,11 +20,6 @@ const pageTitle = title + ' - ' + siteTitle;
     <meta name="og:title" content={title} />
     <meta name="og:description" content={description} />
   </head>
-  <h1>
-    <span className="caption">{subsection}</span>
-    {longTitle}
-  </h1>
-
-CONTENT PLACEHOLDER
-
+  <span className="govuk-caption-xl">{subsection}</span>
+  <Markdown />
 </SubsectionWrap>

--- a/docs/community/README.md
+++ b/docs/community/README.md
@@ -1,0 +1,4 @@
+User-centred design community
+=============================
+
+CONTENT PLACEHOLDER.

--- a/docs/community/events/README.md
+++ b/docs/community/events/README.md
@@ -1,0 +1,4 @@
+Community events
+================
+
+CONTENT PLACEHOLDER.

--- a/docs/community/new-starters/README.md
+++ b/docs/community/new-starters/README.md
@@ -1,0 +1,4 @@
+New starters
+============
+
+CONTENT PLACEHOLDER.

--- a/docs/community/training/README.md
+++ b/docs/community/training/README.md
@@ -1,0 +1,4 @@
+Training
+========
+
+CONTENT PLACEHOLDER.

--- a/docs/community/ucd-ops-team/README.md
+++ b/docs/community/ucd-ops-team/README.md
@@ -1,0 +1,4 @@
+User-centred design ops
+=======================
+
+CONTENT PLACEHOLDER.

--- a/docs/design-and-content/content/README.md
+++ b/docs/design-and-content/content/README.md
@@ -1,0 +1,4 @@
+Content design
+==============
+
+CONTENT PLACEHOLDER.

--- a/docs/design-and-content/content/content-patterns.md
+++ b/docs/design-and-content/content/content-patterns.md
@@ -1,0 +1,4 @@
+Content patterns
+================
+
+CONTENT PLACEHOLDER.

--- a/docs/design-and-content/professional-standards/README.md
+++ b/docs/design-and-content/professional-standards/README.md
@@ -1,0 +1,4 @@
+Professional standards and guidance
+===================================
+
+CONTENT PLACEHOLDER.

--- a/docs/design-and-content/professional-standards/approved-tools.md
+++ b/docs/design-and-content/professional-standards/approved-tools.md
@@ -1,0 +1,4 @@
+Approved tools
+==============
+
+CONTENT PLACEHOLDER.

--- a/docs/design-and-content/professional-standards/designer-role-standard.md
+++ b/docs/design-and-content/professional-standards/designer-role-standard.md
@@ -1,0 +1,4 @@
+Designer role standards
+=======================
+
+CONTENT PLACEHOLDER.

--- a/docs/design-and-content/professional-standards/project-on-off-boarding.md
+++ b/docs/design-and-content/professional-standards/project-on-off-boarding.md
@@ -1,0 +1,4 @@
+Project on-boarding and off-boarding
+====================================
+
+CONTENT PLACEHOLDER.

--- a/docs/user-research/README.md
+++ b/docs/user-research/README.md
@@ -1,0 +1,4 @@
+User research
+=============
+
+CONTENT PLACEHOLDER.

--- a/docs/user-research/ethics/README.md
+++ b/docs/user-research/ethics/README.md
@@ -1,0 +1,4 @@
+Ethical research and consent
+============================
+
+CONTENT PLACEHOLDER.

--- a/docs/user-research/ethics/consent.md
+++ b/docs/user-research/ethics/consent.md
@@ -1,0 +1,4 @@
+Consent
+=======
+
+CONTENT PLACEHOLDER.

--- a/docs/user-research/participant-recruitment/README.md
+++ b/docs/user-research/participant-recruitment/README.md
@@ -1,0 +1,4 @@
+Participant recruitment
+=======================
+
+CONTENT PLACEHOLDER.

--- a/docs/user-research/professional-standards/README.md
+++ b/docs/user-research/professional-standards/README.md
@@ -1,0 +1,4 @@
+Professional standards and guidance
+===================================
+
+CONTENT PLACEHOLDER.

--- a/docs/user-research/professional-standards/approved-tools.md
+++ b/docs/user-research/professional-standards/approved-tools.md
@@ -1,0 +1,4 @@
+Approved tools
+==============
+
+CONTENT PLACEHOLDER.

--- a/docs/user-research/professional-standards/project-on-off-boarding.md
+++ b/docs/user-research/professional-standards/project-on-off-boarding.md
@@ -1,0 +1,4 @@
+Project on-boarding and off-boarding
+====================================
+
+CONTENT PLACEHOLDER.

--- a/docs/user-research/professional-standards/user-researcher-role-standard.md
+++ b/docs/user-research/professional-standards/user-researcher-role-standard.md
@@ -1,0 +1,4 @@
+User researcher role standards
+==============================
+
+CONTENT PLACEHOLDER.


### PR DESCRIPTION
The original approach for Markdown pages won't work in the current system. This adopts a simpler approach making use of simple, raw Markdown files (in `./docs/`) that are imported into the real pages. The downside being that extra work will be required to add brand new pages.