### PR TITLE
UCDM design tweaks

### DIFF
--- a/components/service-navigation/assets/ServiceNavigation.scss
+++ b/components/service-navigation/assets/ServiceNavigation.scss
@@ -5,12 +5,9 @@ $link_colour: govuk_colour('black');
 
 .hods-service-navigation {
   background-color: govuk-colour(white);
+  border: 0 none;
 
   .govuk-width-container {
-    border-color: $hods-brand-colour-purple;
-    border-style: solid;
-    border-width: 0 0 1px 0;
-    margin-bottom: -1px;
     @include govuk-responsive-padding(8, "left");
     @include govuk-responsive-padding(8, "right");
   }

--- a/components/service-navigation/assets/ServiceNavigation.scss
+++ b/components/service-navigation/assets/ServiceNavigation.scss
@@ -32,5 +32,10 @@ $link_colour: govuk_colour('black');
     &__item {
       border-color: $hods-brand-colour-purple;
     }
+
+    &__item--active {
+      font-weight: bold;
+    }
+   
   }
 }

--- a/components/ucdm-header/assets/Header.scss
+++ b/components/ucdm-header/assets/Header.scss
@@ -2,9 +2,6 @@
 
 .hods-ucdm-header {
   background-color: govuk-colour('white');
-  border-color: $govuk-border-colour;
-  border-style: solid;
-  border-width: 0 0 1px 0;
 
   &__link, a {
     text-decoration: none;
@@ -24,10 +21,6 @@
   }
 
   &__container {
-    border-color: $hods-brand-colour-purple;
-    border-style: solid;
-    border-width: 0 0 1px 0;
-    margin-bottom: -1px;
     overflow: hidden;
     position: relative;
     padding-top: 10px;
@@ -57,7 +50,7 @@
     display: inline-block;
     position: relative;
     fill: currentcolor;
-    margin-right: 5px;
+    margin-right: 30px;
     vertical-align: top;
   }
 

--- a/components/ucdm-page/assets/Page.scss
+++ b/components/ucdm-page/assets/Page.scss
@@ -105,7 +105,7 @@ html {
 
   &__navigation {
     &, &.hods-service-navigation {
-      border-color: $govuk-border-colour;
+      border-color: $hods-brand-colour-purple;
       border-style: solid;
       border-width: 0 0 1px 0;
     }

--- a/components/ucdm-section/assets/Section.scss
+++ b/components/ucdm-section/assets/Section.scss
@@ -6,4 +6,8 @@
     @include govuk-responsive-padding(8, "left");
     @include govuk-responsive-padding(8, "right");
   }
+
+  &__navigation .govuk-service-navigation__list__link {
+    text-decoration-thickness: 2px;
+  }
 }

--- a/components/ucdm-section/assets/Section.scss
+++ b/components/ucdm-section/assets/Section.scss
@@ -1,11 +1,6 @@
 @import "@hods/sass-base";
 
 .hods-ucdm-section {
-  &__header {
-    > :last-child {
-      border-bottom: 1px solid $govuk-border-colour;
-    }
-  }
 
   &__container {
     @include govuk-responsive-padding(8, "left");


### PR DESCRIPTION
Styling design tweaks using KISS principles to reduce visual noise and simplify the user interface.
-
Changes have a dependency on removing duplicate section header item in secondary navigation and removing page banner which is currently separating the primary and secondary navigation too much.
-
PR changes as follows:
* Remove multiple horizontal borders from service navigation to reduce overall number of horizontal lines
* Add bold font weight to active item on sub-navigation to make it more intuitive to see which item is currently active
* Increase right margin on header to give logo more space
* Use horizontal line only once (in brand colour) to separate primary and secondary navigation, leaving spacing and page background colour to create visual divisions of primary, secondary navigation and page content