### PR TITLE
Remove page titles by setting banner visibility to false

### DIFF
--- a/apps/docs/src/common/pages/accessibility/index.tsx
+++ b/apps/docs/src/common/pages/accessibility/index.tsx
@@ -12,7 +12,7 @@ const description = 'Information on how to ensure your service is accessible'
 const siteTitle = config.title;
 
 export const SectionWrap: FC<{ children?: ReactNode, showBanner?: boolean }> = ({ children, showBanner }) => (
-  <Section title={title} href="/accessibility/index-new" showBanner={showBanner} navigation={[
+  <Section title={title} href="/accessibility/index-new" showBanner={false} navigation={[
     { href: '/accessibility/page-structure', text: 'Page structure' },
     { href: '/accessibility/interactivity', text: 'Interactivity' },
     { href: '/accessibility/written-content', text: 'Written content' },

--- a/apps/docs/src/common/pages/community/index.mdx
+++ b/apps/docs/src/common/pages/community/index.mdx
@@ -14,7 +14,7 @@ const siteTitle = config.title;
 const pageTitle = title + ' - ' + siteTitle;
 
 export const SectionWrap = ({ children, showBanner }) => (
-  <Section title={title} href="/community" showBanner={showBanner} navigation={[
+  <Section title={title} href="/community" showBanner={false} navigation={[
     { href: '/community/ucd-ops-team', text: 'Meet UCD Ops' },
     { href: '/community/training', text: 'Training' },
     { href: '/community/new-starters', text: 'New starters' },

--- a/apps/docs/src/common/pages/design-and-content/index.tsx
+++ b/apps/docs/src/common/pages/design-and-content/index.tsx
@@ -11,7 +11,7 @@ export const title = 'Design and content';
 const description = 'Interaction and content design in the Home Office';
 
 export const SectionWrap: FC<{ children?: ReactNode, showBanner?: boolean }> = ({ children, showBanner }) => (
-  <Section title={title} href="/design-and-content" showBanner={showBanner} navigation={[
+  <Section title={title} href="/design-and-content"  showBanner={false} navigation={[
     { href: '/design-and-content/content', text: 'Content' },
     { href: '/design-and-content/professional-standards', text: 'Professional standards and guidance' }
   ]}>

--- a/apps/docs/src/common/pages/design-system/index.tsx
+++ b/apps/docs/src/common/pages/design-system/index.tsx
@@ -14,7 +14,7 @@ const longTitle = 'Home Office Design System';
 const description = 'The UK Home Office\'s Design System, implemented in React';
 
 export const SectionWrap: FC<{ children?: ReactNode, showBanner?: boolean }> = ({ children, showBanner }) => (
-  <Section title={title} href="/design-and-content" showBanner={showBanner} navigation={[
+  <Section title={title} href="/design-and-content" showBanner={false} navigation={[
     { href: '/design-system/get-started', text: 'Get started' },
     { href: '/design-system/styles', text: 'Styles' },
     { href: '/design-system/components', text: 'Components' },

--- a/apps/docs/src/common/pages/user-research/index.mdx
+++ b/apps/docs/src/common/pages/user-research/index.mdx
@@ -14,7 +14,7 @@ const siteTitle = config.title;
 const pageTitle = title + ' - ' + siteTitle;
 
 export const SectionWrap = ({ children, showBanner }) => (
-  <Section title={title} href="/user-research" showBanner={showBanner} navigation={[
+  <Section title={title} href="/user-research" showBanner={false} navigation={[
     { href: '/user-research/ethics', text: 'Ethical research and consent' },
     { href: '/user-research/participant-recruitment', text: 'Participant recruitment' },
     { href: '/user-research/professional-standards', text: 'Professional standards and guidance' }


### PR DESCRIPTION
Setting page titles to false to remove the title banner as this duplicates the H1 and puts a divide in the primary and secondary navigation. The primary and sub-navigation should be directly together to keep the navigation in the same place on the page. 