### PR TITLE
Proposed homepage panel style update

### DIFF
--- a/apps/docs/src/common/app.scss
+++ b/apps/docs/src/common/app.scss
@@ -170,23 +170,12 @@ p {
 // New home-page
 .display-panel {
   background-color: govuk-colour('white');
-  position: relative;
-  padding: 40px 20px 20px 20px;
+  border-top: 4px solid $hods-brand-colour-purple;
+  padding: 30px;
   margin-bottom: 30px;
-
+  position: relative;
+  
   @include govuk-media-query($from: tablet) {
     min-height: 15em;
-  }
-
-  &:after {
-    display: block;
-    background-color: $hods-brand-colour-purple;
-    content: "";
-    width: auto;
-    height: 3px;
-    left: 20px;
-    top: 20px;
-    right: 20px;
-    position: absolute;
   }
 }


### PR DESCRIPTION
Propose style change to homepage panels to tidy up the design:

* move floating panel highlight line to become top-border
* adjust spacing on the panel to add balance and readability

Panel before the pull request changes are made:
<img width="1024" height="892" alt="panel-before" src="https://github.com/user-attachments/assets/5020b30b-73c0-48af-9c8f-00efb1d199b2" />

Panel after the pull request changes are made: 
<img width="1024" height="899" alt="panel-after" src="https://github.com/user-attachments/assets/c3e894c0-2aab-464a-959f-1d27a4d8ffbd" />




