### PR TITLE
docs: fix broken internal links for passport details sub-pages

### DIFF
--- a/apps/docs/src/common/pages/design-system/patterns/ask-users-for/passport-details/enter-details.tsx
+++ b/apps/docs/src/common/pages/design-system/patterns/ask-users-for/passport-details/enter-details.tsx
@@ -28,7 +28,7 @@ const Page: FC<PageProps> = () => (
     <p className="govuk-body">Users enter passport details in response to a series of questions.</p>
 
     <h2 className="govuk-heading-l">When to use this pattern</h2>
-    <p className="govuk-body">Entering passport details manually can be a source of error. If you need more trust in the data, you could <A href="/patterns/enter-passport-details/take-upload-photo">take or upload photo</A> or <A href="/patterns/enter-passport-details/scan-passport-chip">scan the chip</A>.</p>
+    <p className="govuk-body">Entering passport details manually can be a source of error. If you need more trust in the data, you could <A href="/design-system/patterns/ask-users-for/passport-details/upload-photo">take or upload photo</A> or <A href="/design-system/patterns/ask-users-for/passport-details/scan-chip">scan the chip</A>.</p>
 
     <p className="govuk-body">Consider whether you need all the information, or just a small amount of it, such as the passport number. Depending on your users or journey, you may find evidence for separating over multiple pages or for including on one page.</p>
 

--- a/apps/docs/src/common/pages/design-system/patterns/ask-users-for/passport-details/index.tsx
+++ b/apps/docs/src/common/pages/design-system/patterns/ask-users-for/passport-details/index.tsx
@@ -27,9 +27,9 @@ const Page: FC<PageProps> = () => (
     </h1>
     <p className="govuk-body">You can ask for passport details in 3 ways. Users can:</p>
     <ul className="govuk-list govuk-list--bullet">
-      <li><A href="./scan-passport-chip">scan the chip</A></li>
-      <li><A href="./take-upload-photo">take or upload a photo</A></li>
-      <li><A href="./manually-enter-details">manually enter the details</A></li>
+      <li><A href="/design-system/patterns/ask-users-for/passport-details/scan-chip">scan the chip</A></li>
+      <li><A href="/design-system/patterns/ask-users-for/passport-details/upload-photo">take or upload a photo</A></li>
+      <li><A href="/design-system/patterns/ask-users-for/passport-details/enter-details">manually enter the details</A></li>
     </ul>
     <p className="govuk-body">Use the <A href="https://www.consilium.europa.eu/prado/en/search-by-document-country.html">public register of identity documents</A> to see the similarities and differences between passports from around the world.</p>
 

--- a/apps/docs/src/common/pages/design-system/patterns/ask-users-for/passport-details/scan-chip.tsx
+++ b/apps/docs/src/common/pages/design-system/patterns/ask-users-for/passport-details/scan-chip.tsx
@@ -39,7 +39,7 @@ const Page: FC<PageProps> = () => (
     <p className="govuk-body">Users can only scan the chip in their passport, if they are using a device with a near field communication (NFC) chip. Phones that can make contactless payments have an NFC chip.</p>
     <p className="govuk-body">For external users, this normally means they need to be using a mobile phone app.</p>
 
-    <p className="govuk-body">To scan the chip, you need the information in the machine-readable zone (MRZ) of the passport. Users should <A href="/patterns/enter-passport-details/take-upload-photo">take or upload a photo</A>.</p>
+    <p className="govuk-body">To scan the chip, you need the information in the machine-readable zone (MRZ) of the passport. Users should <A href="/design-system/patterns/ask-users-for/passport-details/upload-photo">take or upload a photo</A>.</p>
 
     <p className="govuk-body">Scanning the chip in a passport has the highest level of trust. It also collects the largest amount of data, the chip contains:</p>
     <ul className="govuk-list govuk-list--bullet">
@@ -50,7 +50,7 @@ const Page: FC<PageProps> = () => (
 
     <p className="govuk-body">However not all passports have chips, so you’ll need to ask the user whether their passport has a chip or not. You might already know from the context that the passport must have a chip, for example it’s a UK passport from after 2006. To determine whether the passport has a chip, ask the user if the chip symbol is on the front cover (it may be a different colour).</p>
 
-    <p className="govuk-body">Some users with some passports may not be able to tell that their passport has a chip. You should provide an alternative method, such as <A href="/patterns/enter-passport-details/manually-enter-details">manual entry</A>.</p>
+    <p className="govuk-body">Some users with some passports may not be able to tell that their passport has a chip. You should provide an alternative method, such as <A href="/design-system/patterns/ask-users-for/passport-details/enter-details">manual entry</A>.</p>
 
     <div className="app-example">
       <img src={ePassportLogo} />

--- a/apps/docs/src/common/pages/design-system/patterns/ask-users-for/passport-details/upload-photo.tsx
+++ b/apps/docs/src/common/pages/design-system/patterns/ask-users-for/passport-details/upload-photo.tsx
@@ -32,7 +32,7 @@ const Page: FC<PageProps> = () => (
 
     <p className="govuk-body">This method is less trustworthy than reading directly from the chip, but more trustworthy than manual data entry.</p>
 
-    <p className="govuk-body">You may ask users to take or upload a photo, in order to <A href="/patterns/enter-passport-details/scan-passport-chip">scan the chip</A>.</p>
+    <p className="govuk-body">You may ask users to take or upload a photo, in order to <A href="/design-system/patterns/ask-users-for/passport-details/scan-chip">scan the chip</A>.</p>
 
     <h2 className="govuk-heading-l">How it works</h2>
     <p className="govuk-body">You should explain why they need to take a picture of their passport, and provide some helpful tips. Consider providing in-camera guidance, indicating when the passport is lined up and readable.</p>


### PR DESCRIPTION
Fix several occurrences of internal links to sub-pages of [passport details](https://design.homeoffice.gov.uk/design-system/patterns/ask-users-for/passport-details) that are broken. 

I appreciate that I haven't previously created a discussion or issue for this change (as described in your [contributing guidelines](https://github.com/UKHomeOffice/design-system/blob/master/CONTRIBUTING.md)), however I hope that's not necessary for a minor fix to your documentation.