### PR TITLE
correct duplicate 3.3.3 - error suggestion requirement wording

### DIFF
--- a/apps/docs/src/common/pages/accessibility/standard/index.tsx
+++ b/apps/docs/src/common/pages/accessibility/standard/index.tsx
@@ -536,7 +536,7 @@ const Page: FC<PageProps> = () => (
             <A href="/accessibility/standard/understandable#rr3.3.3">3.3.3 - Error suggestions</A>
           </td>
           <td className="govuk-table__cell">
-            <p>When data must be entered in a specific format or in a particular way, clear instructions must be associated with the form field. Password fields should allow a user to view and check the entry.</p>
+            <p>When an error is detected, suggestions for correcting the issue must be provided unless the suggestion compromises security.</p>
           </td>
         </tr>
         <tr className="govuk-table__row">


### PR DESCRIPTION
The summary description for “3.3.3 – Error suggestions” incorrectly duplicates the text from “3.3.2 – Labels or instructions” on the [main accessibility standards page](https://design.homeoffice.gov.uk/accessibility/standard). 

Updated the summary to reflect the correct description, aligning it with the detailed view, resolving the issue identified in https://github.com/UKHomeOffice/design-system/discussions/740.