### PR TITLE
fix: correct stale file links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ We publish our documentation site when pushing to the `master` branch.
 [apps/]: ./apps/
 [lib/]: ./lib/
 [components/]: ./components/
-[pnpm-workspaces.yaml]: ./pnpm-workspaces.yaml
-[plopfile.js]: ./plopfile.js
+[pnpm-workspaces.yaml]: ./pnpm-workspace.yaml
+[plopfile.js]: ./plopfile.mjs
 [install pnpm]: https://pnpm.io/installation
 [PLOP]: https://plopjs.com/
 [documentation application]: ./apps/docs


### PR DESCRIPTION
## What

The README links to two local files under a "Note" about extending the
project's package varieties, and again in the "Creating a new package"
section:

- `[pnpm-workspaces.yaml]: ./pnpm-workspaces.yaml`
- `[plopfile.js]: ./plopfile.js`

Neither file exists any more. The repo has `pnpm-workspace.yaml`
(singular, no "s") and `plopfile.mjs` (renamed from `.js` to `.mjs`).
Both links currently 404.

## Evidence

Verified with real HTTP requests against the live upstream repo:

```
pnpm-workspaces.yaml (as linked today) -> 404
plopfile.js          (as linked today) -> 404
pnpm-workspace.yaml  (actual file)     -> 200
plopfile.mjs         (actual file)     -> 200
```

Also confirmed locally that `./pnpm-workspaces.yaml` and `./plopfile.js`
do not exist in a fresh clone, while `./pnpm-workspace.yaml` and
`./plopfile.mjs` do.

## Change

Updates the two reference-link targets in `README.md` to point at the
files that actually exist now. No other content changed.

- Diff: 1 file changed, 2 insertions, 2 deletions.
- Docs-only change, so it doesn't touch any buildable code.

## Checks

- Repo has no `.github/PULL_REQUEST_TEMPLATE.md`, so this follows the
  repo's plain PR convention instead (checked `.github/`).
- `CONTRIBUTING.md` doesn't ban trivial or drive-by PRs, and the repo
  has merged similar broken-link fixes before (`#730 broken-link-fixes`).
- No AI-assistance policy, DCO sign-off, or CLA requirement found in
  `CONTRIBUTING.md`, `docs/contributing.md`, or `README.md`.
- AI review (manual self-review; `ocr` not installed in this
  environment): change is a 2-line link-target fix, no logic to review.